### PR TITLE
Preferred guild setting

### DIFF
--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -68,7 +68,7 @@ class CharactersMixin:
                 return await self.error_handler(ctx, e)
             gname = guild["name"]
             gtag = guild["tag"]
-            data.add_field(name="Guild", value="[{}] {}".format(gtag, gname))
+        data.add_field(name="Guild", value="[{}] {}".format(gtag, gname))
         data.add_field(name="Deaths", value=deaths)
         data.add_field(
             name="Deaths per hour", value=str(deathsperhour), inline=False)

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -415,9 +415,8 @@ class CharactersMixin:
         data.set_author(name=doc["account_name"], icon_url=ctx.user.avatar_url)
         for character in characters:
             craft_list = self.get_crafting(character)
-            if craft_list is None:
-                craft_list = "-"
-            data.add_field(name=character["name"], value="\n".join(craft_list))
+            if craft_list is not None:
+                data.add_field(name=character["name"], value="\n".join(craft_list))
         try:
             await ctx.send(embed=data)
         except discord.HTTPException:

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -66,16 +66,19 @@ class CharactersMixin:
             gtag = guild["tag"]
             data.add_field(name="Guild", value="[{}] {}".format(gtag, gname))
         data.add_field(name="Deaths", value=deaths)
-        data.add_field(name="Deaths per hour", value=str(deathsperhour), inline=False)
-        # TODO add to one output field
-        if "crafting" in results:
+        data.add_field(
+            name="Deaths per hour", value=str(deathsperhour), inline=False)
+        craftlist = ""
+        if results["crafting"] != []:
             for crafting in results["crafting"]:
                 rating = crafting["rating"]
-                disclipline = crafting["discipline"]
-                data.add_field(name="Crafting", value="Level {0} {1}".format(rating, disclipline))
+                discipline = crafting["discipline"]
+                craftlist += "\n".join(
+                    ["Level {0} {1}\n".format(rating, discipline)])
+            data.add_field(name="Crafting", value=craftlist)
         data.set_author(name=character)
-        data.set_footer(text="A {} {} {}".format(gender.lower(), race,
-                                                 profession))
+        data.set_footer(
+            text="A {} {} {}".format(gender.lower(), race, profession))
         try:
             await ctx.send(embed=data)
         except discord.Forbidden:

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -73,13 +73,9 @@ class CharactersMixin:
         data.add_field(name="Deaths", value=deaths)
         data.add_field(
             name="Deaths per hour", value=str(deathsperhour), inline=False)
-        craft_list = []
-        if results["crafting"]:
-            for crafting in results["crafting"]:
-                rating = crafting["rating"]
-                discipline = crafting["discipline"]
-                craft_list.append("Level {} {}".format(rating, discipline))
-            data.add_field(name="Crafting", value="\n".join(craft_list))
+
+        craft_list = self.get_crafting(results)
+        data.add_field(name="Crafting", value="\n".join(craft_list))
 
         data.set_author(name=character)
         data.set_footer(
@@ -452,3 +448,14 @@ class CharactersMixin:
             except:
                 return None
         return None
+
+    def get_crafting(self, character):
+        craft_list = []
+        if character["crafting"]:
+            for crafting in character["crafting"]:
+                rating = crafting["rating"]
+                discipline = crafting["discipline"]
+                craft_list.append("Level {} {}".format(rating, discipline))
+            return craft_list
+        else:
+            return None

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -401,7 +401,7 @@ class CharactersMixin:
     @commands.cooldown(1, 10, BucketType.user)
     async def character_crafting(self, ctx):
         """Displays your characters and their crafting level"""
-        endpoint = "characters"
+        endpoint = "characters?page=0"
         try:
             characters = await self.call_api(endpoint, ctx.author, ["characters"])
         except APIError as e:
@@ -409,15 +409,14 @@ class CharactersMixin:
         data = discord.Embed(
             description='Crafting overview', colour=self.embed_color)
         for character in characters:
-            char_info = await self.get_character(ctx, character)
             craftlist = ""
-            if char_info["crafting"] != []:
-                for crafting in char_info["crafting"]:
+            if character["crafting"] != []:
+                for crafting in character["crafting"]:
                     rating = crafting["rating"]
                     discipline = crafting["discipline"]
                     craftlist += "\n".join(
                         ["Level {0} {1}\n".format(rating, discipline)])
-                data.add_field(name=char_info["name"], value=craftlist)
+                data.add_field(name=character["name"], value=craftlist)
         try:
             await ctx.send(embed=data)
         except discord.HTTPException:

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -72,14 +72,19 @@ class CharactersMixin:
         data.add_field(name="Deaths", value=deaths)
         data.add_field(
             name="Deaths per hour", value=str(deathsperhour), inline=False)
-        craftlist = ""
-        if results["crafting"] != []:
-            for crafting in results["crafting"]:
-                rating = crafting["rating"]
-                discipline = crafting["discipline"]
-                craftlist += "\n".join(
-                    ["Level {0} {1}\n".format(rating, discipline)])
-            data.add_field(name="Crafting", value=craftlist)
+        endpoint_chars = "characters?page=0"
+        try:
+            characters = await self.call_api(endpoint_chars, ctx.author, ["characters"])
+        except APIError as e:
+            return await self.error_handler(ctx, e)
+        for character in characters:
+            craft_list = []
+            if character["crafting"]:
+                for crafting in character["crafting"]:
+                    rating = crafting["rating"]
+                    discipline = crafting["discipline"]
+                    craft_list.append("Level {} {}".format(rating, discipline))
+                    data.add_field(name=character["name"], value="\n".join(craft_list))
         data.set_author(name=character)
         data.set_footer(
             text="A {} {} {}".format(gender.lower(), race, profession))

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -407,10 +407,12 @@ class CharactersMixin:
         try:
             characters = await self.call_api(endpoint, ctx.author,
                                              ["characters"])
+            doc = await self.fetch_key(ctx.author, ["account"])
         except APIError as e:
             return await self.error_handler(ctx, e)
         data = discord.Embed(
             description='Crafting overview', colour=self.embed_color)
+        data.set_author(name=doc["account_name"], icon_url=ctx.user.avatar_url)
         for character in characters:
             craft_list = self.get_crafting(character)
             data.add_field(name=character["name"], value="\n".join(craft_list))

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -79,7 +79,7 @@ class CharactersMixin:
                 rating = crafting["rating"]
                 discipline = crafting["discipline"]
                 craft_list.append("Level {} {}".format(rating, discipline))
-                data.add_field(name=results["name"], value="\n".join(craft_list))
+            data.add_field(name="Crafting", value="\n".join(craft_list))
 
         data.set_author(name=character)
         data.set_footer(

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -397,6 +397,32 @@ class CharactersMixin:
         if character == "All":
             await user.send("\n".join(output))
 
+    @character.command(name="crafting")
+    @commands.cooldown(1, 10, BucketType.user)
+    async def character_crafting(self, ctx):
+        """Displays your characters and their crafting level"""
+        endpoint = "characters"
+        try:
+            characters = await self.call_api(endpoint, ctx.author, ["characters"])
+        except APIError as e:
+            return await self.error_handler(ctx, e)
+        data = discord.Embed(
+            description='Crafting overview', colour=self.embed_color)
+        for character in characters:
+            char_info = await self.get_character(ctx, character)
+            craftlist = ""
+            if char_info["crafting"] != []:
+                for crafting in char_info["crafting"]:
+                    rating = crafting["rating"]
+                    discipline = crafting["discipline"]
+                    craftlist += "\n".join(
+                        ["Level {0} {1}\n".format(rating, discipline)])
+                data.add_field(name=char_info["name"], value=craftlist)
+        try:
+            await ctx.send(embed=data)
+        except discord.HTTPException:
+            await ctx.send("Need permission to embed links")
+
     async def get_character(self, ctx, character):
         character = character.title()
         endpoint = "characters/" + character.replace(" ", "%20")

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -61,7 +61,11 @@ class CharactersMixin:
         data.add_field(name="Created at", value=created)
         data.add_field(name="Played for", value=age)
         if guild is not None:
-            guild = await self.get_guild(results["guild"])
+            endpoint = "guild/{0}".format(results["guild"])
+            try:
+                guild = await self.call_api(endpoint)
+            except APIError as e:
+                return await self.error_handler(ctx, e)
             gname = guild["name"]
             gtag = guild["tag"]
             data.add_field(name="Guild", value="[{}] {}".format(gtag, gname))

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -415,6 +415,8 @@ class CharactersMixin:
         data.set_author(name=doc["account_name"], icon_url=ctx.user.avatar_url)
         for character in characters:
             craft_list = self.get_crafting(character)
+            if craft_list is None:
+                craft_list = "-"
             data.add_field(name=character["name"], value="\n".join(craft_list))
         try:
             await ctx.send(embed=data)

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -413,7 +413,7 @@ class CharactersMixin:
             return await self.error_handler(ctx, e)
         data = discord.Embed(
             description='Crafting overview', colour=self.embed_color)
-        data.set_author(name=doc["account_name"], icon_url=ctx.user.avatar_url)
+        data.set_author(name=doc["account_name"], icon_url=ctx.author.avatar_url)
         for character in characters:
             craft_list = self.get_crafting(character)
             if craft_list is not None:

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -412,14 +412,8 @@ class CharactersMixin:
         data = discord.Embed(
             description='Crafting overview', colour=self.embed_color)
         for character in characters:
-            craftlist = ""
-            if character["crafting"] != []:
-                for crafting in character["crafting"]:
-                    rating = crafting["rating"]
-                    discipline = crafting["discipline"]
-                    craftlist += "\n".join(
-                        ["Level {0} {1}\n".format(rating, discipline)])
-                data.add_field(name=character["name"], value=craftlist)
+            craft_list = self.get_crafting(character)
+            data.add_field(name=character["name"], value="\n".join(craft_list))
         try:
             await ctx.send(embed=data)
         except discord.HTTPException:

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -32,7 +32,8 @@ class CharactersMixin:
             else:
                 fmt = '{h} hours, {m} minutes, and {s} seconds'
             return fmt.format(d=days, h=hours, m=minutes, s=seconds)
-
+        
+        await ctx.trigger_typing()
         character = character.title()
         endpoint = "characters/" + character.replace(" ", "%20")
         try:
@@ -68,23 +69,18 @@ class CharactersMixin:
                 return await self.error_handler(ctx, e)
             gname = guild["name"]
             gtag = guild["tag"]
-        data.add_field(name="Guild", value="[{}] {}".format(gtag, gname))
+            data.add_field(name="Guild", value="[{}] {}".format(gtag, gname))
         data.add_field(name="Deaths", value=deaths)
         data.add_field(
             name="Deaths per hour", value=str(deathsperhour), inline=False)
-        endpoint_chars = "characters?page=0"
-        try:
-            characters = await self.call_api(endpoint_chars, ctx.author, ["characters"])
-        except APIError as e:
-            return await self.error_handler(ctx, e)
-        for character in characters:
-            craft_list = []
-            if character["crafting"]:
-                for crafting in character["crafting"]:
-                    rating = crafting["rating"]
-                    discipline = crafting["discipline"]
-                    craft_list.append("Level {} {}".format(rating, discipline))
-                    data.add_field(name=character["name"], value="\n".join(craft_list))
+        craft_list = []
+        if character["crafting"]:
+            for crafting in character["crafting"]:
+                rating = crafting["rating"]
+                discipline = crafting["discipline"]
+                craft_list.append("Level {} {}".format(rating, discipline))
+                data.add_field(name=character["name"], value="\n".join(craft_list))
+
         data.set_author(name=character)
         data.set_footer(
             text="A {} {} {}".format(gender.lower(), race, profession))

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -32,7 +32,7 @@ class CharactersMixin:
             else:
                 fmt = '{h} hours, {m} minutes, and {s} seconds'
             return fmt.format(d=days, h=hours, m=minutes, s=seconds)
-        
+
         await ctx.trigger_typing()
         character = character.title()
         endpoint = "characters/" + character.replace(" ", "%20")
@@ -74,12 +74,12 @@ class CharactersMixin:
         data.add_field(
             name="Deaths per hour", value=str(deathsperhour), inline=False)
         craft_list = []
-        if character["crafting"]:
-            for crafting in character["crafting"]:
+        if results["crafting"]:
+            for crafting in results["crafting"]:
                 rating = crafting["rating"]
                 discipline = crafting["discipline"]
                 craft_list.append("Level {} {}".format(rating, discipline))
-                data.add_field(name=character["name"], value="\n".join(craft_list))
+                data.add_field(name=results["name"], value="\n".join(craft_list))
 
         data.set_author(name=character)
         data.set_footer(

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -66,7 +66,13 @@ class CharactersMixin:
             gtag = guild["tag"]
             data.add_field(name="Guild", value="[{}] {}".format(gtag, gname))
         data.add_field(name="Deaths", value=deaths)
-        data.add_field(name="Deaths per hour", value=str(deathsperhour))
+        data.add_field(name="Deaths per hour", value=str(deathsperhour), inline=False)
+        # TODO add to one output field
+        if "crafting" in results:
+            for crafting in results["crafting"]:
+                rating = crafting["rating"]
+                disclipline = crafting["discipline"]
+                data.add_field(name="Crafting", value="Level {0} {1}".format(rating, disclipline))
         data.set_author(name=character)
         data.set_footer(text="A {} {} {}".format(gender.lower(), race,
                                                  profession))

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -402,8 +402,10 @@ class CharactersMixin:
     async def character_crafting(self, ctx):
         """Displays your characters and their crafting level"""
         endpoint = "characters?page=0"
+        await ctx.trigger_typing()
         try:
-            characters = await self.call_api(endpoint, ctx.author, ["characters"])
+            characters = await self.call_api(endpoint, ctx.author,
+                                             ["characters"])
         except APIError as e:
             return await self.error_handler(ctx, e)
         data = discord.Embed(

--- a/guildwars2/characters.py
+++ b/guildwars2/characters.py
@@ -75,7 +75,8 @@ class CharactersMixin:
             name="Deaths per hour", value=str(deathsperhour), inline=False)
 
         craft_list = self.get_crafting(results)
-        data.add_field(name="Crafting", value="\n".join(craft_list))
+        if craft_list is not None:
+            data.add_field(name="Crafting", value="\n".join(craft_list))
 
         data.set_author(name=character)
         data.set_footer(

--- a/guildwars2/commerce.py
+++ b/guildwars2/commerce.py
@@ -276,4 +276,4 @@ class CommerceMixin:
                                   "me blocked, or disabled DMs in this "
                                   "server. Aborting.")
         await self.bot.database.set_user(user, {"gemtrack": price}, self)
-        await ctx.send("Succesfully set")
+        await ctx.send("Successfully set")

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -185,7 +185,8 @@ class GeneralGuild:
                 return await self.error_handler(ctx, e)
         else:
             try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
+                endpoint_id = "guild/search?name=" + guild_name.replace(
+                    ' ', '%20')
                 guild_id = await self.call_api(endpoint_id)
                 guild_id = guild_id[0]
             except (IndexError, APINotFound):
@@ -242,8 +243,8 @@ class GeneralGuild:
                         inline=False)
                     counter += 1
         if counter == 0:
-            return await ctx.send(
-                "No stash log entries yet for {}".format(guild_name.title()))
+            return await ctx.send("No stash log entries yet for {}".format(
+                guild_name.title()))
         try:
             await ctx.send(embed=data)
         except discord.Forbidden:
@@ -264,9 +265,9 @@ class GeneralGuild:
             return await self.error_handler(ctx, e)
 
         # Write to DB, overwrites existing guild
-        await self.bot.database.set_user(ctx.author,
-                                         {"guild": guild_id,
-                                          }, self)
+        await self.bot.database.set_user(ctx.author, {
+            "guild": guild_id,
+        }, self)
 
         await ctx.send("Your preferred guild is now set to {0}"
                        .format(guild_name))
@@ -275,9 +276,9 @@ class GeneralGuild:
     @commands.cooldown(1, 10, BucketType.user)
     async def guild_unset(self, ctx):
         """Removes stored preferred guild"""
-        await self.bot.database.set_user(ctx.author,
-                                         {"guild": "",
-                                          }, self)
+        await self.bot.database.set_user(ctx.author, {
+            "guild": "",
+        }, self)
         await ctx.send("Preferred guild removed.")
 
     async def get_preferred_guild(self, user):

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -189,11 +189,11 @@ class GeneralGuild:
         # Get Guild name if ID already stored
         if guild_id:
             guild_name = await self.guildid_to_guildname(ctx, guild_id)
-            if not ctx.guild:
-                await ctx.send("Preferred guild is only available on server.")
         elif guild_name is not None:
             guild_id = await self.guildname_to_guildid(ctx, guild_name)
         else:
+            if not ctx.guild:
+                await ctx.send("Preferred guild is only available on server.")
             return await self.bot.send_cmd_help(ctx)
 
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -23,16 +23,19 @@ class GeneralGuild:
         Required permissions: guilds
         """
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx)
-        # Get Guild name if ID already stored
-        if guild_id:
-            guild_name = await self.guildid_to_guildname(ctx, guild_id)
-        elif guild_name is not None:
-            guild_id = await self.guildname_to_guildid(ctx, guild_name)
-        else:
+        try:
+            guild = await self.get_guild(ctx, guild_name=guild_name)
+        except (IndexError, APINotFound):
+            return await ctx.send("Invalid guild name")
+        except APIError as e:
+            return await self.error_handler(ctx, e)
+
+        if not guild:
             return await self.bot.send_cmd_help(ctx)
 
         try:
+            guild_id = guild["id"]
+            guild_name = guild["name"]
             endpoint = "guild/{0}".format(guild_id)
             results = await self.call_api(endpoint, ctx.author, ["guilds"])
         except APIError as e:
@@ -72,15 +75,19 @@ class GeneralGuild:
         user = ctx.author
         scopes = ["guilds"]
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx)
-        # Get Guild name if ID already stored
-        if guild_id:
-            guild_name = await self.guildid_to_guildname(ctx, guild_id)
-        elif guild_name is not None:
-            guild_id = await self.guildname_to_guildid(ctx, guild_name)
-        else:
-            return await self.bot.send_cmd_help(ctx)
         try:
+            guild = await self.get_guild(ctx, guild_name=guild_name)
+        except (IndexError, APINotFound):
+            return await ctx.send("Invalid guild name")
+        except APIError as e:
+            return await self.error_handler(ctx, e)
+
+        if not guild:
+            return await self.bot.send_cmd_help(ctx)
+
+        try:
+            guild_id = guild["id"]
+            guild_name = guild["name"]
             endpoints = [
                 "guild/{}/members".format(guild_id),
                 "guild/{}/ranks".format(guild_id)
@@ -125,16 +132,19 @@ class GeneralGuild:
 
         Required permissions: guilds and in game permissions"""
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx)
-        # Get Guild name if ID already stored
-        if guild_id:
-            guild_name = await self.guildid_to_guildname(ctx, guild_id)
-        elif guild_name is not None:
-            guild_id = await self.guildname_to_guildid(ctx, guild_name)
-        else:
+        try:
+            guild = await self.get_guild(ctx, guild_name=guild_name)
+        except (IndexError, APINotFound):
+            return await ctx.send("Invalid guild name")
+        except APIError as e:
+            return await self.error_handler(ctx, e)
+
+        if not guild:
             return await self.bot.send_cmd_help(ctx)
 
         try:
+            guild_id = guild["id"]
+            guild_name = guild["name"]
             endpoint = "guild/{0}/treasury".format(guild_id)
             treasury = await self.call_api(endpoint, ctx.author, ["guilds"])
         except APIForbidden:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -183,7 +183,7 @@ class GeneralGuild:
                 guild_name = results["name"]
             except APIError as e:
                 return await self.error_handler(ctx, e)
-        elif 1==1:
+        elif guild_name is not None:
             try:
                 endpoint_id = "guild/search?name=" + guild_name.replace(
                     ' ', '%20')
@@ -197,10 +197,6 @@ class GeneralGuild:
                     "use this command")
             except APIError as e:
                 return await self.error_handler(ctx, e)
-            except AttributeError:
-                return await ctx.send(
-                    "Please set a preferred guild or use one as a"
-                    " parameter.")
         else:
             await ctx.send("Please set a preferred guild or use one as a"
                     " parameter.")

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -294,4 +294,4 @@ class GeneralGuild:
 
             await ctx.send(
                 "Your preferred guild is now set to {0} for this server"
-                .format(guild_name))
+                .format(guild_name.title()))

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -170,7 +170,7 @@ class GeneralGuild:
     @commands.cooldown(1, 10, BucketType.user)
     async def guild_log(self, ctx, *, guild_name=None):
         """Get log of last 20 entries of stash
-
+        usage="<guild name>"
         Required permissions: guilds and in game permissions"""
 
         # Read preferred guild from DB
@@ -198,8 +198,7 @@ class GeneralGuild:
             except APIError as e:
                 return await self.error_handler(ctx, e)
         else:
-            await ctx.send("Please set a preferred guild or use one as a"
-                    " parameter.")
+            await self.bot.send_cmd_help(ctx)
 
         try:
             endpoint = "guild/{0}/log/".format(guild_id)

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -68,7 +68,7 @@ class GeneralGuild:
     @guild.command(name="members", usage="<guild name>")
     @commands.cooldown(1, 20, BucketType.user)
     async def guild_members(self, ctx, *, guild_name=None):
-        """Get list of all members and their ranks.
+        """Get list of the first 20 members and their ranks.
         Only displays the highest ranks.
 
         Required permissions: guilds and in game permissions

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -243,11 +243,14 @@ class GeneralGuild:
 
     @guild.command(name="set")
     @commands.cooldown(1, 10, BucketType.user)
-    async def guild_set(self, ctx, *, guild_name: str):
+    async def guild_default(self, ctx, *, guild_name=None):
         """ Set your preferred guild for guild commands"""
 
         if guild_name is None:
-            await self.bot.send_cmd_help(ctx)
+            await self.bot.database.set_user(ctx.author, {
+                "guild": "",
+            }, self)
+            await ctx.send("Your preferred guild is now reset")
         else:
             # Get guildname / guild_id from API
             endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
@@ -266,15 +269,6 @@ class GeneralGuild:
 
             await ctx.send("Your preferred guild is now set to {0}"
                            .format(guild_name))
-
-    @guild.command(name="unset")
-    @commands.cooldown(1, 10, BucketType.user)
-    async def guild_unset(self, ctx):
-        """Removes stored preferred guild"""
-        await self.bot.database.set_user(ctx.author, {
-            "guild": "",
-        }, self)
-        await ctx.send("Preferred guild removed.")
 
     async def get_preferred_guild(self, user):
         doc = await self.bot.database.get_user(user, self)

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -196,7 +196,7 @@ class GeneralGuild:
             return await self.bot.send_cmd_help(ctx)
 
         try:
-            endpoint = "guild/{0}/log/".format(guild["id]"])
+            endpoint = "guild/{0}/log/".format(guild["guild_id]"])
             log = await self.call_api(endpoint, ctx.author, ["guilds"])
         except APIForbidden:
             return await ctx.send(

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -34,7 +34,8 @@ class GeneralGuild:
                 return await self.error_handler(ctx, e)
         elif guild_name is not None:
             try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
+                endpoint_id = "guild/search?name=" + guild_name.replace(
+                    ' ', '%20')
                 guild_id = await self.call_api(endpoint_id)
                 guild_id = guild_id[0]
 
@@ -96,7 +97,8 @@ class GeneralGuild:
                 return await self.error_handler(ctx, e)
         elif guild_name is not None:
             try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
+                endpoint_id = "guild/search?name=" + guild_name.replace(
+                    ' ', '%20')
                 guild_id = await self.call_api(endpoint_id)
                 guild_id = guild_id[0]
             except (IndexError, APINotFound):

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -271,11 +271,8 @@ class GeneralGuild:
                            .format(guild_name))
 
     async def get_preferred_guild(self, user):
-        doc = await self.bot.database.get_user(user, self)
-        guild_id = None
-        if doc is not None and doc.get("guild"):
-            guild_id = doc.get("guild")
-        return guild_id
+        doc = await self.bot.database.get_user(user, self) or {}
+        return doc.get("guild")
 
     async def guildid_to_guildname(self, guild_id):
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -264,8 +264,11 @@ class GeneralGuild:
 
     async def get_preferred_guild(self, ctx, user):
         guild = ctx.guild
+        guild_id = None
         doc = await self.bot.database.get_guild(guild, self) or {}
-        return doc.get("guild_ingame")
+        if doc is not None and doc.get("guild_ingame"):
+            guild_id = doc.get("guild_ingame")
+        return guild_id
 
     async def guildid_to_guildname(self, ctx, guild_id):
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -259,8 +259,12 @@ class GeneralGuild:
     @commands.guild_only()
     @commands.cooldown(1, 10, BucketType.user)
     async def guild_default(self, ctx, *, guild_name=None):
-        """ Set your preferred guild for guild commands"""
+        """ Set your preferred guild for guild commands on this Discord Server.
+        Commands from the guild command group invoked
+        without a guild name will default to this guild.
 
+        Invoke this command without an argument to reset the default guild.
+        """
         guild = ctx.guild
         if guild_name is None:
             await self.bot.database.set_guild(guild, {

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -176,7 +176,7 @@ class GeneralGuild:
         # Read preferred guild from DB
         guild_id = await self.get_preferred_guild(ctx.author)
         # Get Guild name if ID already stored
-        if guild_id != "":
+        if guild_id:
             try:
                 endpoint_name = "guild/{0}".format(guild_id)
                 results = await self.call_api(endpoint_name)
@@ -283,7 +283,7 @@ class GeneralGuild:
 
     async def get_preferred_guild(self, user):
         doc = await self.bot.database.get_user(user, self)
-        guild_id = ""
+        guild_id = None
         if doc is not None and doc.get("guild"):
             guild_id = doc.get("guild")
         return guild_id

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -183,7 +183,7 @@ class GeneralGuild:
                 guild_name = results["name"]
             except APIError as e:
                 return await self.error_handler(ctx, e)
-        else:
+        elif 1==1:
             try:
                 endpoint_id = "guild/search?name=" + guild_name.replace(
                     ' ', '%20')
@@ -201,6 +201,10 @@ class GeneralGuild:
                 return await ctx.send(
                     "Please set a preferred guild or use one as a"
                     " parameter.")
+        else:
+            await ctx.send("Please set a preferred guild or use one as a"
+                    " parameter.")
+
         try:
             endpoint = "guild/{0}/log/".format(guild_id)
             log = await self.call_api(endpoint, ctx.author, ["guilds"])

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -241,7 +241,7 @@ class GeneralGuild:
         except discord.Forbidden:
             await ctx.send("Need permission to embed links")
 
-    @guild.command(name="set")
+    @guild.command(name="default")
     @commands.cooldown(1, 10, BucketType.user)
     async def guild_default(self, ctx, *, guild_name=None):
         """ Set your preferred guild for guild commands"""

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -185,17 +185,15 @@ class GeneralGuild:
         Required permissions: guilds and in game permissions"""
 
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx)
-        # Get Guild name if ID already stored
-        if guild_id:
-            guild_name = await self.guildid_to_guildname(ctx, guild_id)
-        elif guild_name is not None:
-            guild_id = await self.guildname_to_guildid(ctx, guild_name)
-        else:
-            return await self.bot.send_cmd_help(ctx)
+        try:
+            guild = await self.get_guild(ctx, guild_name)
+        except (IndexError, APINotFound):
+            return await ctx.send("Invalid guild name")
+        except APIError as e:
+            return await self.error_handler(ctx, e)
 
         try:
-            endpoint = "guild/{0}/log/".format(guild_id)
+            endpoint = "guild/{0}/log/".format(guild["id]"])
             log = await self.call_api(endpoint, ctx.author, ["guilds"])
         except APIForbidden:
             return await ctx.send(

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -264,11 +264,12 @@ class GeneralGuild:
 
     async def get_preferred_guild(self, ctx, user):
         guild = ctx.guild
-        guild_id = None
-        doc = await self.bot.database.get_guild(guild, self) or {}
-        if doc is not None and doc.get("guild_ingame"):
-            guild_id = doc.get("guild_ingame")
-        return guild_id
+        if guild:
+            doc = await self.bot.database.get_guild(guild, self) or {}
+            return doc.get("guild_ingame")
+        else:
+            return await ctx.send("Preferred guild is only available on server.")
+
 
     async def guildid_to_guildname(self, ctx, guild_id):
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -3,6 +3,7 @@ import datetime
 import discord
 from discord.ext import commands
 from discord.ext.commands.cooldowns import BucketType
+from discord.ext.commands.errors import BadArgument
 
 from ..exceptions import APIError, APIForbidden, APINotFound
 
@@ -13,7 +14,7 @@ class GeneralGuild:
         """Guild related commands.
         """
         if ctx.invoked_subcommand is None:
-            await self.bot.send_cmd_help(ctx)
+            raise BadArgument
 
     @guild.command(name="info", usage="<guild name>")
     @commands.cooldown(1, 20, BucketType.user)
@@ -31,7 +32,7 @@ class GeneralGuild:
             return await self.error_handler(ctx, e)
 
         if not guild:
-            return await self.bot.send_cmd_help(ctx)
+            raise BadArgument
 
         try:
             guild_id = guild["id"]
@@ -83,7 +84,7 @@ class GeneralGuild:
             return await self.error_handler(ctx, e)
 
         if not guild:
-            return await self.bot.send_cmd_help(ctx)
+            raise BadArgument
 
         try:
             guild_id = guild["id"]
@@ -140,7 +141,7 @@ class GeneralGuild:
             return await self.error_handler(ctx, e)
 
         if not guild:
-            return await self.bot.send_cmd_help(ctx)
+            raise BadArgument
 
         try:
             guild_id = guild["id"]
@@ -203,7 +204,7 @@ class GeneralGuild:
             return await self.error_handler(ctx, e)
 
         if not guild:
-            return await self.bot.send_cmd_help(ctx)
+            raise BadArgument
 
         try:
             guild_id = guild["id"]

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -189,6 +189,8 @@ class GeneralGuild:
         # Get Guild name if ID already stored
         if guild_id:
             guild_name = await self.guildid_to_guildname(ctx, guild_id)
+            if not ctx.guild:
+                await ctx.send("Preferred guild is only available on server.")
         elif guild_name is not None:
             guild_id = await self.guildname_to_guildid(ctx, guild_name)
         else:
@@ -252,7 +254,8 @@ class GeneralGuild:
                 await self.bot.database.set_guild(guild, {
                     "guild_ingame": "",
                 }, self)
-                await ctx.send("Your preferred guild is now reset for this server.")
+                await ctx.send(
+                    "Your preferred guild is now reset for this server.")
             else:
                 guild_id = await self.guildname_to_guildid(ctx, guild_name)
                 # Write to DB, overwrites existing guild
@@ -260,19 +263,19 @@ class GeneralGuild:
                     "guild_ingame": guild_id,
                 }, self)
 
-                await ctx.send("Your preferred guild is now set to {0} for this server"
-                               .format(guild_name))
+                await ctx.send(
+                    "Your preferred guild is now set to {0} for this server"
+                    .format(guild_name))
         else:
-            return await ctx.send("Preferred guild is only available on server.")
+            return await ctx.send(
+                "Preferred guild is only available on server.")
 
     async def get_preferred_guild(self, ctx):
+        # guild in this case is the server ID
         guild = ctx.guild
         if guild:
             doc = await self.bot.database.get_guild(guild, self) or {}
             return doc.get("guild_ingame")
-        else:
-            await ctx.send("Preferred guild is only available on server.")
-            return None
 
     async def guildid_to_guildname(self, ctx, guild_id):
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -300,13 +300,10 @@ class GeneralGuild:
             guild_id = guild_id[0]
             return guild_id
         except (IndexError, APINotFound):
-            return await
-            ctx.send("Invalid guild name")
+            return await ctx.send("Invalid guild name")
         except APIForbidden:
-            return await
-            ctx.send(
+            return await ctx.send(
                 "You don't have enough permissions in game to "
                 "use this command")
         except APIError as e:
-            return await
-            self.error_handler(ctx, e)
+            return await self.error_handler(ctx, e)

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -253,6 +253,10 @@ class GeneralGuild:
     @commands.cooldown(1, 10, BucketType.user)
     async def guild_set(self, ctx, *, guild_name=None):
         """ Set your preferred guild for guild commands"""
+
+        if ctx.invoked_subcommand is None:
+            await self.bot.send_cmd_help(ctx)
+            
         # Get guildname / guild_id from API
         endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -187,7 +187,6 @@ class GeneralGuild:
         # Read preferred guild from DB
         try:
             guild = await self.get_guild(ctx, guild_name=guild_name)
-            guild_id = guild["id"]
         except (IndexError, APINotFound):
             return await ctx.send("Invalid guild name")
         except APIError as e:
@@ -197,6 +196,7 @@ class GeneralGuild:
             return await self.bot.send_cmd_help(ctx)
 
         try:
+            guild_id = guild["id"]
             endpoint = "guild/{0}/log/".format(guild_id)
             log = await self.call_api(endpoint, ctx.author, ["guilds"])
         except APIForbidden:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -197,6 +197,7 @@ class GeneralGuild:
 
         try:
             guild_id = guild["id"]
+            guild_name = guild["name"]
             endpoint = "guild/{0}/log/".format(guild_id)
             log = await self.call_api(endpoint, ctx.author, ["guilds"])
         except APIForbidden:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -256,24 +256,24 @@ class GeneralGuild:
 
         if ctx.invoked_subcommand is None:
             await self.bot.send_cmd_help(ctx)
-            
-        # Get guildname / guild_id from API
-        endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
-        try:
-            guild_id = await self.call_api(endpoint_id)
-            guild_id = guild_id[0]
-        except (IndexError, APINotFound):
-            return await ctx.send("Invalid guild name")
-        except APIError as e:
-            return await self.error_handler(ctx, e)
+        else:
+            # Get guildname / guild_id from API
+            endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
+            try:
+                guild_id = await self.call_api(endpoint_id)
+                guild_id = guild_id[0]
+            except (IndexError, APINotFound):
+                return await ctx.send("Invalid guild name")
+            except APIError as e:
+                return await self.error_handler(ctx, e)
 
-        # Write to DB, overwrites existing guild
-        await self.bot.database.set_user(ctx.author, {
-            "guild": guild_id,
-        }, self)
+            # Write to DB, overwrites existing guild
+            await self.bot.database.set_user(ctx.author, {
+                "guild": guild_id,
+            }, self)
 
-        await ctx.send("Your preferred guild is now set to {0}"
-                       .format(guild_name))
+            await ctx.send("Your preferred guild is now set to {0}"
+                           .format(guild_name))
 
     @guild.command(name="unset")
     @commands.cooldown(1, 10, BucketType.user)

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -186,7 +186,8 @@ class GeneralGuild:
 
         # Read preferred guild from DB
         try:
-            guild = await self.get_guild(ctx, guild_name)
+            guild = await self.get_guild(ctx, guild_name=guild_name)
+            guild_id = guild["id"]
         except (IndexError, APINotFound):
             return await ctx.send("Invalid guild name")
         except APIError as e:
@@ -196,7 +197,7 @@ class GeneralGuild:
             return await self.bot.send_cmd_help(ctx)
 
         try:
-            endpoint = "guild/{0}/log/".format(guild["guild_id]"])
+            endpoint = "guild/{0}/log/".format(guild_id)
             log = await self.call_api(endpoint, ctx.author, ["guilds"])
         except APIForbidden:
             return await ctx.send(

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -26,23 +26,9 @@ class GeneralGuild:
         guild_id = await self.get_preferred_guild(ctx.author)
         # Get Guild name if ID already stored
         if guild_id:
-            try:
-                endpoint_name = "guild/{0}".format(guild_id)
-                results = await self.call_api(endpoint_name)
-                guild_name = results["name"]
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_name = await self.guildid_to_guildname(guild_id)
         elif guild_name is not None:
-            try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(
-                    ' ', '%20')
-                guild_id = await self.call_api(endpoint_id)
-                guild_id = guild_id[0]
-
-            except (IndexError, APINotFound):
-                return await ctx.send("Invalid guild name")
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_id = await self.guildname_to_guildid(guild_name)
         else:
             return await self.bot.send_cmd_help(ctx)
 
@@ -83,35 +69,17 @@ class GeneralGuild:
 
         Required permissions: guilds and in game permissions
         """
-        # Read preferred guild from DB
         user = ctx.author
         scopes = ["guilds"]
+        # Read preferred guild from DB
         guild_id = await self.get_preferred_guild(ctx.author)
         # Get Guild name if ID already stored
         if guild_id:
-            try:
-                endpoint_name = "guild/{0}".format(guild_id)
-                results = await self.call_api(endpoint_name)
-                guild_name = results["name"]
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_name = await self.guildid_to_guildname(guild_id)
         elif guild_name is not None:
-            try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(
-                    ' ', '%20')
-                guild_id = await self.call_api(endpoint_id)
-                guild_id = guild_id[0]
-            except (IndexError, APINotFound):
-                return await ctx.send("Invalid guild name")
-            except APIForbidden:
-                return await ctx.send(
-                    "You don't have enough permissions in game to "
-                    "use this command")
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_id = await self.guildname_to_guildid(guild_name)
         else:
             return await self.bot.send_cmd_help(ctx)
-
         try:
             endpoints = [
                 "guild/{}/members".format(guild_id),
@@ -124,7 +92,6 @@ class GeneralGuild:
                 "use this command")
         except APIError as e:
             return await self.error_handler(ctx, e)
-
         data = discord.Embed(description="Members", colour=self.embed_color)
         data.set_author(name=guild_name.title())
         counter = 0
@@ -161,26 +128,9 @@ class GeneralGuild:
         guild_id = await self.get_preferred_guild(ctx.author)
         # Get Guild name if ID already stored
         if guild_id:
-            try:
-                endpoint_name = "guild/{0}".format(guild_id)
-                results = await self.call_api(endpoint_name)
-                guild_name = results["name"]
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_name = await self.guildid_to_guildname(guild_id)
         elif guild_name is not None:
-            try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(
-                    ' ', '%20')
-                guild_id = await self.call_api(endpoint_id)
-                guild_id = guild_id[0]
-            except (IndexError, APINotFound):
-                return await ctx.send("Invalid guild name")
-            except APIForbidden:
-                return await ctx.send(
-                    "You don't have enough permissions in game to "
-                    "use this command")
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_id = await self.guildname_to_guildid(guild_name)
         else:
             return await self.bot.send_cmd_help(ctx)
 
@@ -238,26 +188,9 @@ class GeneralGuild:
         guild_id = await self.get_preferred_guild(ctx.author)
         # Get Guild name if ID already stored
         if guild_id:
-            try:
-                endpoint_name = "guild/{0}".format(guild_id)
-                results = await self.call_api(endpoint_name)
-                guild_name = results["name"]
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_name = await self.guildid_to_guildname(guild_id)
         elif guild_name is not None:
-            try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(
-                    ' ', '%20')
-                guild_id = await self.call_api(endpoint_id)
-                guild_id = guild_id[0]
-            except (IndexError, APINotFound):
-                return await ctx.send("Invalid guild name")
-            except APIForbidden:
-                return await ctx.send(
-                    "You don't have enough permissions in game to "
-                    "use this command")
-            except APIError as e:
-                return await self.error_handler(ctx, e)
+            guild_id = await self.guildname_to_guildid(guild_name)
         else:
             return await self.bot.send_cmd_help(ctx)
 
@@ -349,3 +282,31 @@ class GeneralGuild:
         if doc is not None and doc.get("guild"):
             guild_id = doc.get("guild")
         return guild_id
+
+    async def guildid_to_guildname(self, guild_id):
+        try:
+            endpoint_name = "guild/{0}".format(guild_id)
+            results = await self.call_api(endpoint_name)
+            guild_name = results["name"]
+            return guild_name
+        except APIError as e:
+            return await self.error_handler(ctx, e)
+
+    async def guildname_to_guildid(self, guild_name):
+        try:
+            endpoint_id = "guild/search?name=" + guild_name.replace(
+                ' ', '%20')
+            guild_id = await self.call_api(endpoint_id)
+            guild_id = guild_id[0]
+            return guild_id
+        except (IndexError, APINotFound):
+            return await
+            ctx.send("Invalid guild name")
+        except APIForbidden:
+            return await
+            ctx.send(
+                "You don't have enough permissions in game to "
+                "use this command")
+        except APIError as e:
+            return await
+            self.error_handler(ctx, e)

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -268,7 +268,8 @@ class GeneralGuild:
             doc = await self.bot.database.get_guild(guild, self) or {}
             return doc.get("guild_ingame")
         else:
-            return await ctx.send("Preferred guild is only available on server.")
+            await ctx.send("Preferred guild is only available on server.")
+            return None
 
 
     async def guildid_to_guildname(self, ctx, guild_id):

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -170,7 +170,6 @@ class GeneralGuild:
     @commands.cooldown(1, 10, BucketType.user)
     async def guild_log(self, ctx, *, guild_name=None):
         """Get log of last 20 entries of stash
-        usage="<guild name>"
         Required permissions: guilds and in game permissions"""
 
         # Read preferred guild from DB
@@ -198,7 +197,7 @@ class GeneralGuild:
             except APIError as e:
                 return await self.error_handler(ctx, e)
         else:
-            await self.bot.send_cmd_help(ctx)
+            return await self.bot.send_cmd_help(ctx)
 
         try:
             endpoint = "guild/{0}/log/".format(guild_id)

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -192,6 +192,9 @@ class GeneralGuild:
         except APIError as e:
             return await self.error_handler(ctx, e)
 
+        if not guild:
+            return await self.bot.send_cmd_help(ctx)
+
         try:
             endpoint = "guild/{0}/log/".format(guild["id]"])
             log = await self.call_api(endpoint, ctx.author, ["guilds"])

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -246,25 +246,26 @@ class GeneralGuild:
     async def guild_default(self, ctx, *, guild_name=None):
         """ Set your preferred guild for guild commands"""
 
+        guild = ctx.guild
         if guild_name is None:
-            await self.bot.database.set_user(ctx.author, {
-                "guild": "",
+            await self.bot.database.set_guild(guild, {
+                "guild_ingame": "",
             }, self)
-            await ctx.send("Your preferred guild is now reset")
+            await ctx.send("Your preferred guild is now reset for this server.")
         else:
             guild_id = await self.guildname_to_guildid(ctx, guild_name)
             # Write to DB, overwrites existing guild
-            await self.bot.database.set_user(ctx.author, {
-                "guild": guild_id,
+            await self.bot.database.set_guild(guild, {
+                "guild_ingame": guild_id,
             }, self)
 
-            await ctx.send("Your preferred guild is now set to {0}"
+            await ctx.send("Your preferred guild is now set to {0} for this server"
                            .format(guild_name))
 
     async def get_preferred_guild(self, ctx, user):
         guild = ctx.guild
-        doc = await self.bot.database.get_user(user, self) or {}
-        return doc.get("guild")
+        doc = await self.bot.database.get_guild(guild, self) or {}
+        return doc.get("guild_ingame")
 
     async def guildid_to_guildname(self, ctx, guild_id):
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -30,6 +30,8 @@ class GeneralGuild:
         elif guild_name is not None:
             guild_id = await self.guildname_to_guildid(ctx, guild_name)
         else:
+            if not ctx.guild:
+                await ctx.send("Preferred guild is only available on server.")
             return await self.bot.send_cmd_help(ctx)
 
         try:
@@ -79,6 +81,8 @@ class GeneralGuild:
         elif guild_name is not None:
             guild_id = await self.guildname_to_guildid(ctx, guild_name)
         else:
+            if not ctx.guild:
+                await ctx.send("Preferred guild is only available on server.")
             return await self.bot.send_cmd_help(ctx)
         try:
             endpoints = [
@@ -132,6 +136,8 @@ class GeneralGuild:
         elif guild_name is not None:
             guild_id = await self.guildname_to_guildid(ctx, guild_name)
         else:
+            if not ctx.guild:
+                await ctx.send("Preferred guild is only available on server.")
             return await self.bot.send_cmd_help(ctx)
 
         try:

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -258,6 +258,7 @@ class GeneralGuild:
     @guild.command(name="default", usage="<guild name>")
     @commands.guild_only()
     @commands.cooldown(1, 10, BucketType.user)
+    @commands.has_permissions(manage_guild=True)
     async def guild_default(self, ctx, *, guild_name=None):
         """ Set your preferred guild for guild commands on this Discord Server.
         Commands from the guild command group invoked

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -110,7 +110,7 @@ class GeneralGuild:
 
     @guild.command(name="treasury")
     @commands.cooldown(1, 20, BucketType.user)
-    async def guild_treasury(self, ctx, *, guild_name: str):
+    async def guild_treasury(self, ctx, *, guild_name=None):
         """Get list of current and needed items for upgrades
 
         Required permissions: guilds and in game permissions"""
@@ -126,7 +126,8 @@ class GeneralGuild:
                 return await self.error_handler(ctx, e)
         elif guild_name is not None:
             try:
-                endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
+                endpoint_id = "guild/search?name=" + guild_name.replace(
+                    ' ', '%20')
                 guild_id = await self.call_api(endpoint_id)
                 guild_id = guild_id[0]
             except (IndexError, APINotFound):
@@ -137,10 +138,6 @@ class GeneralGuild:
                     "use this command")
             except APIError as e:
                 return await self.error_handler(ctx, e)
-            except AttributeError:
-                return await ctx.send(
-                    "Please set a preferred guild or use one as a"
-                    " parameter.")
         else:
             return await self.bot.send_cmd_help(ctx)
 

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -178,7 +178,9 @@ class GeneralGuild:
         # Get Guild name if ID already stored
         if guild_id != "":
             try:
-                guild_name = self.get_guildname(guild_id)
+                endpoint_name = "guild/{0}".format(guild_id)
+                results = await self.call_api(endpoint_name)
+                guild_name = results["name"]
             except APIError as e:
                 return await self.error_handler(ctx, e)
         else:
@@ -284,8 +286,3 @@ class GeneralGuild:
         if doc is not None and doc.get("guild"):
             guild_id = doc.get("guild")
         return guild_id
-
-    async def get_guildname(self, guild_id):
-        endpoint_name = "guild/{0}".format(guild_id)
-        results = await self.call_api(endpoint_name)
-        return results["name"]

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -129,8 +129,6 @@ class GeneralGuild:
                 endpoint_id = "guild/search?name=" + guild_name.replace(' ', '%20')
                 guild_id = await self.call_api(endpoint_id)
                 guild_id = guild_id[0]
-                endpoint = "guild/{0}/treasury".format(guild_id)
-                treasury = await self.call_api(endpoint, ctx.author, ["guilds"])
             except (IndexError, APINotFound):
                 return await ctx.send("Invalid guild name")
             except APIForbidden:
@@ -145,6 +143,18 @@ class GeneralGuild:
                     " parameter.")
         else:
             return await self.bot.send_cmd_help(ctx)
+
+        try:
+            endpoint = "guild/{0}/treasury".format(guild_id)
+            treasury = await self.call_api(endpoint, ctx.author, ["guilds"])
+        except (IndexError, APINotFound):
+            return await ctx.send("Invalid guild name")
+        except APIForbidden:
+            return await ctx.send(
+                "You don't have enough permissions in game to "
+                "use this command")
+        except APIError as e:
+            return await self.error_handler(ctx, e)
 
         data = discord.Embed(description="Treasury", colour=self.embed_color)
         data.set_author(name=guild_name.title())

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -250,10 +250,10 @@ class GeneralGuild:
 
     @guild.command(name="set")
     @commands.cooldown(1, 10, BucketType.user)
-    async def guild_set(self, ctx, *, guild_name=None):
+    async def guild_set(self, ctx, *, guild_name: str):
         """ Set your preferred guild for guild commands"""
 
-        if ctx.invoked_subcommand is None:
+        if guild_name is None:
             await self.bot.send_cmd_help(ctx)
         else:
             # Get guildname / guild_id from API

--- a/guildwars2/guild/general.py
+++ b/guildwars2/guild/general.py
@@ -23,7 +23,7 @@ class GeneralGuild:
         Required permissions: guilds
         """
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx, ctx.author)
+        guild_id = await self.get_preferred_guild(ctx)
         # Get Guild name if ID already stored
         if guild_id:
             guild_name = await self.guildid_to_guildname(ctx, guild_id)
@@ -72,7 +72,7 @@ class GeneralGuild:
         user = ctx.author
         scopes = ["guilds"]
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx, ctx.author)
+        guild_id = await self.get_preferred_guild(ctx)
         # Get Guild name if ID already stored
         if guild_id:
             guild_name = await self.guildid_to_guildname(ctx, guild_id)
@@ -125,7 +125,7 @@ class GeneralGuild:
 
         Required permissions: guilds and in game permissions"""
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx, ctx.author)
+        guild_id = await self.get_preferred_guild(ctx)
         # Get Guild name if ID already stored
         if guild_id:
             guild_name = await self.guildid_to_guildname(ctx, guild_id)
@@ -185,7 +185,7 @@ class GeneralGuild:
         Required permissions: guilds and in game permissions"""
 
         # Read preferred guild from DB
-        guild_id = await self.get_preferred_guild(ctx, ctx.author)
+        guild_id = await self.get_preferred_guild(ctx)
         # Get Guild name if ID already stored
         if guild_id:
             guild_name = await self.guildid_to_guildname(ctx, guild_id)
@@ -247,22 +247,25 @@ class GeneralGuild:
         """ Set your preferred guild for guild commands"""
 
         guild = ctx.guild
-        if guild_name is None:
-            await self.bot.database.set_guild(guild, {
-                "guild_ingame": "",
-            }, self)
-            await ctx.send("Your preferred guild is now reset for this server.")
+        if guild:
+            if guild_name is None:
+                await self.bot.database.set_guild(guild, {
+                    "guild_ingame": "",
+                }, self)
+                await ctx.send("Your preferred guild is now reset for this server.")
+            else:
+                guild_id = await self.guildname_to_guildid(ctx, guild_name)
+                # Write to DB, overwrites existing guild
+                await self.bot.database.set_guild(guild, {
+                    "guild_ingame": guild_id,
+                }, self)
+
+                await ctx.send("Your preferred guild is now set to {0} for this server"
+                               .format(guild_name))
         else:
-            guild_id = await self.guildname_to_guildid(ctx, guild_name)
-            # Write to DB, overwrites existing guild
-            await self.bot.database.set_guild(guild, {
-                "guild_ingame": guild_id,
-            }, self)
+            return await ctx.send("Preferred guild is only available on server.")
 
-            await ctx.send("Your preferred guild is now set to {0} for this server"
-                           .format(guild_name))
-
-    async def get_preferred_guild(self, ctx, user):
+    async def get_preferred_guild(self, ctx):
         guild = ctx.guild
         if guild:
             doc = await self.bot.database.get_guild(guild, self) or {}
@@ -270,7 +273,6 @@ class GeneralGuild:
         else:
             await ctx.send("Preferred guild is only available on server.")
             return None
-
 
     async def guildid_to_guildname(self, ctx, guild_id):
         try:


### PR DESCRIPTION
Added $guild set and $guild unset to store preferred Guild in database 
If guild is set, other guild commands (like treasury or info) can be invoked without explicitly typing the guild name again