### PR TITLE
$guildsync guildrole toggle command

### DIFF
--- a/guildwars2/guild/sync.py
+++ b/guildwars2/guild/sync.py
@@ -2,7 +2,6 @@ import discord
 from discord.ext import commands
 from discord.ext.commands.cooldowns import BucketType
 import asyncio
-import copy
 
 from ..exceptions import APIError, APIForbidden, APINotFound, APIKeyError
 
@@ -182,7 +181,6 @@ class SyncGuild:
         guilddoc = doc["sync"]
         guild = self.bot.get_guild(doc["_id"])
         enabled = self.sync_enabled(doc)
-        newname = copy.deepcopy(guilddoc["ranks"])
         if not enabled:
             await ctx.send(
                 "You need to run setup before you can toggle the guild role.")
@@ -196,11 +194,11 @@ class SyncGuild:
                         name=guilddoc["name"],
                         reason="GW2Bot Sync Role [$guildsync]",
                         color=discord.Color(self.embed_color))
-                    newname[guilddoc["name"]] = role.id
+                    guilddoc["ranks"][guilddoc["name"]] = role.id
                 except discord.Forbidden:
                     return await ctx.send(
                         "Couldn't create role {0}".format(guilddoc["name"]))
-                await self.bot.database.set_guild(guild, {"sync.ranks": newname},
+                await self.bot.database.set_guild(guild, {"sync.ranks": guilddoc["ranks"]},
                                             self)
             msg = ("Guild role enabled and created. Guild sync needs to run for members to be synced to the role.")
         else:

--- a/guildwars2/guild/sync.py
+++ b/guildwars2/guild/sync.py
@@ -101,9 +101,10 @@ class SyncGuild:
             guild_id = guild_id[0]
             endpoints = [
                 "guild/{}/members".format(guild_id),
-                "guild/{}/ranks".format(guild_id)
+                "guild/{}/ranks".format(guild_id),
+                "guild/{}".format(guild_id)
             ]
-            results, ranks = await self.call_multiple(endpoints, ctx.author,
+            results, ranks, info = await self.call_multiple(endpoints, ctx.author,
                                                       scopes)
         except (IndexError, APINotFound):
             return await ctx.send("Invalid guild name")
@@ -133,7 +134,7 @@ class SyncGuild:
             "sync.setupdone": True,
             "sync.on": True,
             "sync.guildrole": False,
-            "sync.name": answer.content,
+            "sync.name": "[{0}]".format(info['tag']),
             "sync.gid": guild_id
         }, self)
         guidelines = (

--- a/guildwars2/guild/sync.py
+++ b/guildwars2/guild/sync.py
@@ -179,7 +179,7 @@ class SyncGuild:
 
     @guildsync.command(name="guildrole")
     async def guildrole_toggle(self, ctx, on_off: bool):
-        """Toggles guildrole on/off - does not wipe settings"""
+        """Toggles guildrole on/off. Adds a new role based on the guild tag (ie. [ANET]) for simpler channel management."""
         doc = await self.bot.database.get_guild(ctx.guild, self)
         guilddoc = doc["sync"]
         guild = self.bot.get_guild(doc["_id"])

--- a/guildwars2/guild/sync.py
+++ b/guildwars2/guild/sync.py
@@ -315,6 +315,8 @@ class SyncGuild:
                                           self)
         gw2members = await self.getmembers(leader, gid)
         rolelist = []
+        if guildrole:
+            guildrole = discord.utils.get(guild.roles, id=guilddoc["ranks"][guildrole])
         for role_id in newsaved.values():
             discordrole = discord.utils.get(guild.roles, id=role_id)
             rolelist.append(discordrole)
@@ -353,10 +355,8 @@ class SyncGuild:
                                         pass
                                 await self.add_member_to_role(desiredrole, member, guild)
                             if guildrole:
-                                desiredguildrole = discord.utils.get(
-                                    guild.roles, id=guilddoc["ranks"][guildrole])
-                                if desiredguildrole not in member.roles:
-                                    await self.add_member_to_role(desiredguildrole, member, guild)
+                                if guildrole not in member.roles:
+                                    await self.add_member_to_role(guildrole, member, guild)
                         except Exception as e:
                             self.log.debug(
                                 "Couldn't get the role object for {0} user "

--- a/guildwars2/guild/sync.py
+++ b/guildwars2/guild/sync.py
@@ -177,7 +177,7 @@ class SyncGuild:
         await ctx.send(msg)
 
     @guildsync.command(name="guildrole")
-    async def sync_toggle(self, ctx, on_off: bool):
+    async def guildrole_toggle(self, ctx, on_off: bool):
         """Toggles guildrole on/off - does not wipe settings"""
         doc = await self.bot.database.get_guild(ctx.guild, self)
         guilddoc = doc["sync"]
@@ -235,11 +235,10 @@ class SyncGuild:
 
     async def add_member_to_role(self, role, member, guild):
         try:
-            results = await member.add_roles(
+            await member.add_roles(
                 role,
                 reason="GW2Bot Integration [$guildsync]"
             )
-            return results
         except discord.Forbidden:
             self.log.debug(
                 "Permissions error when trying to "
@@ -257,7 +256,7 @@ class SyncGuild:
         name = self.__class__.__name__
         guilddoc = doc["cogs"][name]["sync"]
         enabled = guilddoc.get("on", False)
-        guildrole = guilddoc["name"] if guilddoc.get("guildrole", False) else False
+        guildrole = guilddoc["name"] if guilddoc.get("guildrole", False) else None
         if not enabled:
             return
         guild = self.bot.get_guild(doc["_id"])

--- a/guildwars2/guild/sync.py
+++ b/guildwars2/guild/sync.py
@@ -37,6 +37,8 @@ class SyncGuild:
             "sync.leader": None,
             "sync.setupdone": False,
             "sync.on": False,
+            "sync.guildrole": False,
+            "sync.name": None,
             "sync.gid": None
         }, self)
 


### PR DESCRIPTION
Add `$guildsync guildrole on/off`. 
- Creates a new role based off the name of the guild when toggled on.
- Adds the guild role to the list of allowed ranks.
- Adds all members with an in-game rank to the umbrella guild role.
- Forces a guild sync when toggled off to delete the role.