### PR TITLE
added search for upgrades in items

### DIFF
--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -389,8 +389,8 @@ class AccountMixin:
                 for item in bag:
                     bag_total += check(item)
             equipment = 0
-                for piece in character["equipment"]:
-                    equipment += check(piece)
+            for piece in character["equipment"]:
+                equipment += check(piece)
             count = bag_total + equipment
             storage_counts[character["name"]] = count
         seq = [k for k, v in storage_counts.items() if v]

--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -353,7 +353,7 @@ class AccountMixin:
                 if item["count"] is not None:
                     return item["count"]
                 return 1
-            if choice["isUpgrade"] is None:
+            if choice.get("isUpgrade") is None:
                 return 0
 
             def countUpgrades(iteratable):
@@ -363,11 +363,11 @@ class AccountMixin:
                         infusions_sum += 1
                 return infusions_sum
 
-            if item["infusions"] is not None:
+            if item.get("infusions") is not None:
                 infusions_sum = countUpgrades(item["infusions"])
                 if infusions_sum is not 0:
                     return infusions_sum
-            if item["upgrades"] is not None:
+            if item.get("upgrades") is not None:
                 upgrades_sum = countUpgrades(item["upgrades"])
                 if upgrades_sum is not 0:
                     return upgrades_sum

--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -353,7 +353,7 @@ class AccountMixin:
                 if item["count"] is not None:
                     return item["count"]
                 return 1
-            if choice["type"] is not "UpgradeComponent":
+            if choice["isUpgrade"] is None:
                 return 0
 
             def countUpgrades(iteratable):
@@ -372,7 +372,7 @@ class AccountMixin:
                 if upgrades_sum is not 0:
                     return upgrades_sum
             return 0
-            
+
 
         storage_counts = OrderedDict()
         for k, v in storage_spaces.items():

--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -350,7 +350,7 @@ class AccountMixin:
             if item is None:
                 return 0
             if item["id"] in choice["ids"]:
-                if item["count"] is not None:
+                if item.get("count") is not None:
                     return item["count"]
                 return 1
             if choice.get("isUpgrade") is None:
@@ -365,11 +365,11 @@ class AccountMixin:
 
             if item.get("infusions") is not None:
                 infusions_sum = countUpgrades(item["infusions"])
-                if infusions_sum is not 0:
+                if infusions_sum != 0:
                     return infusions_sum
             if item.get("upgrades") is not None:
                 upgrades_sum = countUpgrades(item["upgrades"])
-                if upgrades_sum is not 0:
+                if upgrades_sum != 0:
                     return upgrades_sum
             return 0
 

--- a/guildwars2/database.py
+++ b/guildwars2/database.py
@@ -429,7 +429,7 @@ class DatabaseMixin:
 
         for item in items:
             if item["_id"] in choice["ids"]:
-                if item["type"] is "UpgradeComponent":
+                if item["type"] == "UpgradeComponent":
                     choice["isUpgrade"] = True
 
         return choice

--- a/guildwars2/database.py
+++ b/guildwars2/database.py
@@ -326,13 +326,13 @@ class DatabaseMixin:
         def consolidate_duplicates(items):
             unique_items = collections.OrderedDict()
             for item in items:
-                item_tuple = item["name"], item["rarity"]
+                item_tuple = item["name"], item["rarity"], item["type"]
                 if item_tuple not in unique_items:
                     unique_items[item_tuple] = []
                 unique_items[item_tuple].append(item["_id"])
             unique_list = []
             for k, v in unique_items.items():
-                unique_list.append({"name": k[0], "rarity": k[1], "ids": v})
+                unique_list.append({"name": k[0], "rarity": k[1], "type": k[2], "ids": v})
             return unique_list
 
         def check(m):

--- a/guildwars2/database.py
+++ b/guildwars2/database.py
@@ -394,14 +394,14 @@ class DatabaseMixin:
                     "-" * (longest))
         ]
 
-        items_copy = items
         if group_duplicates:
-            items = consolidate_duplicates(items)
+            crunched_items = consolidate_duplicates(items)
         else:
             for item in items:
                 item["ids"] = [item["_id"]]
+            crunched_items = items
         if number != 1:
-            for c, m in enumerate(items, 1):
+            for c, m in enumerate(crunched_items, 1):
                 msg.append("  {} {}| {} {}| {}".format(c, " " * (
                     2 - len(str(c))), m["name"].upper(), " " * (
                         4 + longest - len(m["name"])), m["rarity"]))
@@ -415,7 +415,7 @@ class DatabaseMixin:
                 return None
             try:
                 num = int(answer.content) - 1
-                choice = items[num]
+                choice = crunched_items[num]
             except:
                 await message.edit(content="That's not a number in the list")
                 return None
@@ -425,9 +425,9 @@ class DatabaseMixin:
             except:
                 pass
         else:
-            choice = items[0]
+            choice = crunched_items[0]
 
-        for item in items_copy:
+        for item in items:
             if item["_id"] in choice["ids"]:
                 if item["type"] is "UpgradeComponent":
                     choice["isUpgrade"] = true

--- a/guildwars2/database.py
+++ b/guildwars2/database.py
@@ -394,20 +394,12 @@ class DatabaseMixin:
                     "-" * (longest))
         ]
 
-        def isUpgrade(original, iteratable):
-            for i in original:
-                if i["_id"] in iteratable:
-                    if i["type"] is "UpgradeComponent":
-                        return true
-            return false
-
         items_copy = items
         if group_duplicates:
             items = consolidate_duplicates(items)
         else:
             for item in items:
                 item["ids"] = [item["_id"]]
-        isUpgrade(items_copy, items["ids"])
         if number != 1:
             for c, m in enumerate(items, 1):
                 msg.append("  {} {}| {} {}| {}".format(c, " " * (
@@ -434,4 +426,10 @@ class DatabaseMixin:
                 pass
         else:
             choice = items[0]
+
+        for item in items_copy:
+            if item["_id"] in choice["ids"]:
+                if item["type"] is "UpgradeComponent":
+                    choice["isUpgrade"] = true
+
         return choice

--- a/guildwars2/database.py
+++ b/guildwars2/database.py
@@ -430,6 +430,6 @@ class DatabaseMixin:
         for item in items:
             if item["_id"] in choice["ids"]:
                 if item["type"] is "UpgradeComponent":
-                    choice["isUpgrade"] = true
+                    choice["isUpgrade"] = True
 
         return choice

--- a/guildwars2/database.py
+++ b/guildwars2/database.py
@@ -272,8 +272,8 @@ class DatabaseMixin:
                 if not ids:
                     print("{} done".format(endpoint))
                     break
-                itemgroup = await self.call_api(
-                    "{}?ids={}".format(endpoint, ids))
+                itemgroup = await self.call_api("{}?ids={}".format(
+                    endpoint, ids))
                 await bulk_write(itemgroup)
                 counter += 200
         else:
@@ -284,7 +284,7 @@ class DatabaseMixin:
         start = time.time()
         self.bot.available = False
         await self.bot.change_presence(
-            game=discord.Game(name="Rebuilding API cache"),
+            activity=discord.Game(name="Rebuilding API cache"),
             status=discord.Status.dnd)
         endpoints = [["items"], ["achievements"], ["itemstats", True], [
             "titles", True
@@ -336,8 +336,8 @@ class DatabaseMixin:
             return unique_list
 
         def check(m):
-            if isinstance(destination, (discord.abc.User,
-                                        discord.abc.PrivateChannel)):
+            if isinstance(destination,
+                          (discord.abc.User, discord.abc.PrivateChannel)):
                 chan = isinstance(m.channel, discord.abc.PrivateChannel)
             else:
                 chan = m.channel == destination.channel
@@ -345,9 +345,13 @@ class DatabaseMixin:
 
         item_sanitized = re.escape(item)
         search = re.compile(item_sanitized + ".*", re.IGNORECASE)
-        cursor = self.db[database].find({"name": search,
-                                         "flags": {"$nin": flags},
-                                         **filters})
+        cursor = self.db[database].find({
+            "name": search,
+            "flags": {
+                "$nin": flags
+            },
+            **filters
+        })
         number = await cursor.count()
         if not number:
             await destination.send(
@@ -367,9 +371,13 @@ class DatabaseMixin:
                 return
             exact_match = "^" + item_sanitized + "$"
             search = re.compile(exact_match, re.IGNORECASE)
-            cursor = self.db[database].find({"name": search,
-                                             "flags": {"$nin": flags},
-                                             **filters})
+            cursor = self.db[database].find({
+                "name": search,
+                "flags": {
+                    "$nin": flags
+                },
+                **filters
+            })
             number = await cursor.count()
             if not number:
                 await destination.send(
@@ -395,16 +403,16 @@ class DatabaseMixin:
         ]
 
         if group_duplicates:
-            crunched_items = consolidate_duplicates(items)
+            distinct_items = consolidate_duplicates(items)
         else:
             for item in items:
                 item["ids"] = [item["_id"]]
-            crunched_items = items
+            distinct_items = items
         if number != 1:
-            for c, m in enumerate(crunched_items, 1):
-                msg.append("  {} {}| {} {}| {}".format(c, " " * (
-                    2 - len(str(c))), m["name"].upper(), " " * (
-                        4 + longest - len(m["name"])), m["rarity"]))
+            for c, m in enumerate(distinct_items, 1):
+                msg.append("  {} {}| {} {}| {}".format(
+                    c, " " * (2 - len(str(c))), m["name"].upper(),
+                    " " * (4 + longest - len(m["name"])), m["rarity"]))
             msg.append("```")
             message = await destination.send("\n".join(msg))
             try:
@@ -415,7 +423,7 @@ class DatabaseMixin:
                 return None
             try:
                 num = int(answer.content) - 1
-                choice = crunched_items[num]
+                choice = distinct_items[num]
             except:
                 await message.edit(content="That's not a number in the list")
                 return None
@@ -425,11 +433,11 @@ class DatabaseMixin:
             except:
                 pass
         else:
-            choice = crunched_items[0]
+            choice = distinct_items[0]
 
         for item in items:
             if item["_id"] in choice["ids"]:
                 if item["type"] == "UpgradeComponent":
-                    choice["isUpgrade"] = True
+                    choice["is_upgrade"] = True
 
         return choice

--- a/guildwars2/database.py
+++ b/guildwars2/database.py
@@ -326,13 +326,13 @@ class DatabaseMixin:
         def consolidate_duplicates(items):
             unique_items = collections.OrderedDict()
             for item in items:
-                item_tuple = item["name"], item["rarity"], item["type"]
+                item_tuple = item["name"], item["rarity"]
                 if item_tuple not in unique_items:
                     unique_items[item_tuple] = []
                 unique_items[item_tuple].append(item["_id"])
             unique_list = []
             for k, v in unique_items.items():
-                unique_list.append({"name": k[0], "rarity": k[1], "type": k[2], "ids": v})
+                unique_list.append({"name": k[0], "rarity": k[1], "ids": v})
             return unique_list
 
         def check(m):
@@ -393,8 +393,21 @@ class DatabaseMixin:
                 " " * (longest)), "-----|------{}|-------".format(
                     "-" * (longest))
         ]
+
+        def isUpgrade(original, iteratable):
+            for i in original:
+                if i["_id"] in iteratable:
+                    if i["type"] is "UpgradeComponent":
+                        return true
+            return false
+
+        items_copy = items
         if group_duplicates:
             items = consolidate_duplicates(items)
+        else:
+            for item in items:
+                item["ids"] = [item["_id"]]
+        isUpgrade(items_copy, items["ids"])
         if number != 1:
             for c, m in enumerate(items, 1):
                 msg.append("  {} {}| {} {}| {}".format(c, " " * (


### PR DESCRIPTION
fixes #42 
api doesnt allow to search through upgrades in shared inventory slots. only if the upgrade changes the item id, so thats not included