### PR TITLE
Add a kill proof command

### DIFF
--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -327,7 +327,7 @@ class AccountMixin:
         try:
             doc = await self.fetch_key(user, scopes)
             endpoint = "account/achievements?ids=" + ",".join(achievement_ids)
-            results = await self.call_api(endpoint, user, ["progression"])
+            results = await self.call_api(endpoint, key=doc["key"])
         except APINotFound as e:
             # Not Found is returned by the API when none of the searched
             # achievements have been completed yet.

--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -310,52 +310,12 @@ class AccountMixin:
             return await ctx.send("Need permission to embed links")
         await ctx.trigger_typing()
 
-        wings = {
-                "Spirit Vale": [
-                    {"name": "Vale Guardian", "type": "single", "id": 2654},
-                    {"name": "Gorseval", "type": "single", "id": 2649},
-                    {"name": "Sabetha", "type": "single", "id": 2659}
-                ],
-                "Salvation Pass": [
-                    {"name": "Slothasor", "type": "single", "id": 2826},
-                    # There is no achievement for the Bandit Trio without
-                    # special conditions, so we can't know it wasn't done.
-                    {"name": "Bandit Trio", "type": "any_or_none", "ids": [2830, 2831]},
-                    {"name": "Matthias", "type": "single", "id": 2836}
-                ],
-                "Stronghold of the Faithful": [
-                    {"name": "Escort", "type": "single", "id": 3024}, 
-                    {"name": "Keep Construct", "type": "single", "id": 3014},
-                    {"name": "Twisted Castle", "type": "single", "id": 3010},
-                    {"name": "Xera", "type": "single", "id": 3017}
-                ],
-                "Bastion of the Penitent": [
-                    {"name": "Cairn", "type": "single", "id": 3349},
-                    {"name": "Cairn CM", "type": "single", "id": 3334},
-                    {"name": "Mursaat Overseer", "type": "single", "id": 3321},
-                    {"name": "Mursaat Overseer CM", "type": "single", "id": 3287},
-                    {"name": "Samarog", "type": "single", "id": 3347},
-                    {"name": "Samarog CM", "type": "single", "id": 3342},
-                    {"name": "Deimos", "type": "single", "id": 3364},
-                    {"name": "Deimos CM", "type": "single", "id": 3292}
-                ],
-                "Hall of Chains": [
-                    {"name": "Soulless Horror", "type": "single", "id": 4004},
-                    {"name": "Soulless Horror CM", "type": "single", "id": 3993},
-                    {"name": "River of Souls", "type": "single", "id": 4010},
-                    {"name": "Statues of Grenth", "type": "all", "ids": [3998, 4036, 4038]},
-                    {"name": "Voice in the Void", "type": "single", "id": 4016},
-                    {"name": "Voice in the Void CM", "type": "single", "id": 3979}
-                ],
-                "Fractals": [
-                    {"name": "Nightmare CM", "type": "single", "id": 3180},
-                    {"name": "Shattered Observatory CM", "type": "single", "id": 3465}
-                ],
-        }
+        areas = self.gamedata["killproofs"]["areas"]
+        areas = OrderedDict(sorted(areas.items(), key=lambda x: x[1]["order"]))
 
-        # Create a list of lists of ids.
-        achievement_ids = [[x["id"]] if x["type"] == "single" else x["ids"]
-                for x in chain.from_iterable(wings.values())]
+        # Create a list of lists of all achievement ids we need to check.
+        achievement_ids = [[x["id"]] if x["type"] == "single_achievement" else x["ids"]
+                for x in chain.from_iterable([area["encounters"] for area in areas.values()])]
         # Flatten it.
         achievement_ids = [str(x) for x in chain.from_iterable(achievement_ids)]
 
@@ -372,14 +332,14 @@ class AccountMixin:
 
         def is_killed(boss):
             # If the achievement is finished, the encounter was completed
-            if boss["type"] == "single":
+            if boss["type"] == "single_achievement":
                 for achievement in results:
                     if achievement["id"] == boss["id"] and achievement["done"]:
                         return "+";
                 # The achievement is not in the list or isn't done
                 return "-"
             # If all achievements were completed, the encounter was completed
-            if boss["type"] == "all":
+            if boss["type"] == "all_achievements":
                 for id in boss["ids"]:
                     found = False
                     for achievement in results:
@@ -391,7 +351,7 @@ class AccountMixin:
                 return "+"
             # If any of these achievements are completed, the encounter was
             # completed, otherwise we don't know.
-            if boss["type"] == "any_or_none":
+            if boss["type"] == "any_achievement_or_none":
                 for id in boss["ids"]:
                     for achievement in results:
                         if achievement["id"] == id and achievement["done"]:
@@ -400,13 +360,13 @@ class AccountMixin:
 
         embed = discord.Embed(title="Kill Proof", color=self.embed_color)
         embed.set_author(name=doc["account_name"], icon_url=user.avatar_url)
-        for wing in wings:
+        for area in areas:
             value = ["```diff"]
-            bosses = wings[wing]
+            bosses = areas[area]["encounters"]
             for boss in bosses:
                 value.append(is_killed(boss) + boss["name"])
             value.append("```")
-            embed.add_field(name=wing, value="\n".join(value))
+            embed.add_field(name=area, value="\n".join(value))
 
         embed.description = "List of encounters that were completed by this player."
         embed.set_footer(text="Green (+) means completed. Red (-) means not. Gray (?) means unknown.")

--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -311,14 +311,12 @@ class AccountMixin:
         await ctx.trigger_typing()
 
         areas = self.gamedata["killproofs"]["areas"]
-        areas = OrderedDict(sorted(areas.items(), key=lambda x: x[1]["order"]))
 
         # Create a list of lists of all achievement ids we need to check.
         achievement_ids = [[x["id"]]
                            if x["type"] == "single_achievement" else x["ids"]
                            for x in chain.from_iterable(
-                               [area["encounters"]
-                                for area in areas.values()])]
+                               [area["encounters"] for area in areas])]
         # Flatten it.
         achievement_ids = [
             str(x) for x in chain.from_iterable(achievement_ids)
@@ -366,11 +364,11 @@ class AccountMixin:
         embed.set_author(name=doc["account_name"], icon_url=user.avatar_url)
         for area in areas:
             value = ["```diff"]
-            encounters = areas[area]["encounters"]
+            encounters = area["encounters"]
             for encounter in encounters:
                 value.append(is_completed(encounter) + encounter["name"])
             value.append("```")
-            embed.add_field(name=area, value="\n".join(value))
+            embed.add_field(name=area["name"], value="\n".join(value))
 
         embed.description = "List of completed encounters"
         embed.set_footer(text="Green (+) means completed. Red (-) means not. "

--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -314,14 +314,15 @@ class AccountMixin:
         areas = OrderedDict(sorted(areas.items(), key=lambda x: x[1]["order"]))
 
         # Create a list of lists of all achievement ids we need to check.
-        achievement_ids = [
-                [x["id"]] if x["type"] == "single_achievement" else x["ids"]
-                for x in chain.from_iterable(
-                    [area["encounters"] for area in areas.values()]
-                )
-            ]
+        achievement_ids = [[x["id"]]
+                           if x["type"] == "single_achievement" else x["ids"]
+                           for x in chain.from_iterable(
+                               [area["encounters"]
+                                for area in areas.values()])]
         # Flatten it.
-        achievement_ids = [str(x) for x in chain.from_iterable(achievement_ids)]
+        achievement_ids = [
+            str(x) for x in chain.from_iterable(achievement_ids)
+        ]
 
         try:
             doc = await self.fetch_key(user, scopes)
@@ -375,8 +376,8 @@ class AccountMixin:
         embed.set_footer(text="Green (+) means completed. Red (-) means not. "
                          "Gray (?) means unknown.")
 
-        await ctx.send("{.mention}, here is your kill proof.".format(user),
-                       embed=embed)
+        await ctx.send(
+            "{.mention}, here is your kill proof.".format(user), embed=embed)
 
     @commands.command()
     @commands.cooldown(1, 10, BucketType.user)

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -514,33 +514,34 @@
     }
   },
   "killproofs": {
-    "areas": {
-      "Spirit Vale": {
+    "areas": [
+      {
+        "name": "Spirit Vale",
         "encounters": [
           {"name": "Vale Guardian", "type": "single_achievement", "id": 2654},
           {"name": "Gorseval", "type": "single_achievement", "id": 2649},
           {"name": "Sabetha", "type": "single_achievement", "id": 2659}
-        ],
-        "order": 0
+        ]
       },
-      "Salvation Pass": {
+      {
+        "name": "Salvation Pass",
         "encounters": [
           {"name": "Slothasor", "type": "single_achievement", "id": 2826},
           {"name": "Bandit Trio", "type": "any_achievement_or_none", "ids": [2830, 2831]},
           {"name": "Matthias", "type": "single_achievement", "id": 2836}
-          ],
-        "order": 1
+        ]
       },
-      "Stronghold of the Faithful": {
+      {
+        "name": "Stronghold of the Faithful",
         "encounters": [
           {"name": "Escort", "type": "single_achievement", "id": 3024},
           {"name": "Keep Construct", "type": "single_achievement", "id": 3014},
           {"name": "Twisted Castle", "type": "single_achievement", "id": 3010},
           {"name": "Xera", "type": "single_achievement", "id": 3017}
-        ],
-        "order": 2
+        ]
       },
-      "Bastion of the Penitent": {
+      {
+        "name": "Bastion of the Penitent",
         "encounters": [
           {"name": "Cairn", "type": "single_achievement", "id": 3349},
           {"name": "Cairn CM", "type": "single_achievement", "id": 3334},
@@ -550,10 +551,10 @@
           {"name": "Samarog CM", "type": "single_achievement", "id": 3342},
           {"name": "Deimos", "type": "single_achievement", "id": 3364},
           {"name": "Deimos CM", "type": "single_achievement", "id": 3292}
-        ],
-        "order": 3
+        ]
       },
-      "Hall of Chains": {
+      {
+        "name": "Hall of Chains",
         "encounters": [
           {"name": "Soulless Horror", "type": "single_achievement", "id": 4004},
           {"name": "Soulless Horror CM", "type": "single_achievement", "id": 3993},
@@ -561,17 +562,16 @@
           {"name": "Statues of Grenth", "type": "all_achievements", "ids": [3998, 4036, 4038]},
           {"name": "Voice in the Void", "type": "single_achievement", "id": 4016},
           {"name": "Voice in the Void CM", "type": "single_achievement", "id": 3979}
-        ],
-        "order": 4
+        ]
       },
-      "Fractals": {
+      {
+        "name": "Fractals",
         "encounters": [
           {"name": "Nightmare CM", "type": "single_achievement", "id": 3180},
           {"name": "Shattered Observatory CM", "type": "single_achievement", "id": 3465}
-        ],
-        "order": 5
+        ]
       }
-    }
+    ]
   },
   "cats": {
     "chicken": {

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -513,6 +513,66 @@
       "perfected_envoy_shoes": 80399
     }
   },
+  "killproofs": {
+    "areas": {
+      "Spirit Vale": {
+        "encounters": [
+          {"name": "Vale Guardian", "type": "single_achievement", "id": 2654},
+          {"name": "Gorseval", "type": "single_achievement", "id": 2649},
+          {"name": "Sabetha", "type": "single_achievement", "id": 2659}
+        ],
+        "order": 0
+      },
+      "Salvation Pass": {
+        "encounters": [
+          {"name": "Slothasor", "type": "single_achievement", "id": 2826},
+          {"name": "Bandit Trio", "type": "any_achievement_or_none", "ids": [2830, 2831]},
+          {"name": "Matthias", "type": "single_achievement", "id": 2836}
+          ],
+        "order": 1
+      },
+      "Stronghold of the Faithful": {
+        "encounters": [
+          {"name": "Escort", "type": "single_achievement", "id": 3024},
+          {"name": "Keep Construct", "type": "single_achievement", "id": 3014},
+          {"name": "Twisted Castle", "type": "single_achievement", "id": 3010},
+          {"name": "Xera", "type": "single_achievement", "id": 3017}
+        ],
+        "order": 2
+      },
+      "Bastion of the Penitent": {
+        "encounters": [
+          {"name": "Cairn", "type": "single_achievement", "id": 3349},
+          {"name": "Cairn CM", "type": "single_achievement", "id": 3334},
+          {"name": "Mursaat Overseer", "type": "single_achievement", "id": 3321},
+          {"name": "Mursaat Overseer CM", "type": "single_achievement", "id": 3287},
+          {"name": "Samarog", "type": "single_achievement", "id": 3347},
+          {"name": "Samarog CM", "type": "single_achievement", "id": 3342},
+          {"name": "Deimos", "type": "single_achievement", "id": 3364},
+          {"name": "Deimos CM", "type": "single_achievement", "id": 3292}
+        ],
+        "order": 3
+      },
+      "Hall of Chains": {
+        "encounters": [
+          {"name": "Soulless Horror", "type": "single_achievement", "id": 4004},
+          {"name": "Soulless Horror CM", "type": "single_achievement", "id": 3993},
+          {"name": "River of Souls", "type": "single_achievement", "id": 4010},
+          {"name": "Statues of Grenth", "type": "all_achievements", "ids": [3998, 4036, 4038]},
+          {"name": "Voice in the Void", "type": "single_achievement", "id": 4016},
+          {"name": "Voice in the Void CM", "type": "single_achievement", "id": 3979}
+        ],
+        "order": 4
+      },
+      "Fractals": {
+        "encounters": [
+          {"name": "Nightmare CM", "type": "single_achievement", "id": 3180},
+          {"name": "Shattered Observatory CM", "type": "single_achievement", "id": 3465}
+        ],
+        "order": 5
+      }
+    }
+  },
   "cats": {
     "chicken": {
       "name": "Slab of Poultry Meat - WP: [&BPoAAAA=]",


### PR DESCRIPTION
Adds a command for checking which raid and fractal encounters were completed.

### Issues
- The requirements are hardcoded, there is no way around that as far as I know.
- When more raids/fractals are added, they will have to be added.
- The layout isn't very pretty

### TODO
- Double-check achievement ids
- Mention in README?

### Potential improvements
- Find amount of kill proof items in inventories (or spent in case of Shattered Observatory CM).