### PR TITLE
Add localized versions for the wiki command

### DIFF
--- a/guildwars2/misc.py
+++ b/guildwars2/misc.py
@@ -24,9 +24,9 @@ class MiscMixin:
             "fr": "https://wiki-fr.guildwars2.com",
             "es": "https://wiki-es.guildwars2.com"}
         searchurl = {"en": "{}/index.php?title=Special%3ASearch&search={}",
-               "de": "{}/index.php?search={}&title=Spezial%3ASuche&",
-               "fr": "{}/index.php?search={}&title=Spécial%3ARecherche",
-               "es": "{}/index.php?title=Especial%3ABuscar&search={}"}
+            "de": "{}/index.php?search={}&title=Spezial%3ASuche&",
+            "fr": "{}/index.php?search={}&title=Spécial%3ARecherche",
+            "es": "{}/index.php?title=Especial%3ABuscar&search={}"}
         lang = search.split(" ")[-1]
         if lang in wiki:
             search = search[:-3]

--- a/guildwars2/misc.py
+++ b/guildwars2/misc.py
@@ -11,10 +11,22 @@ from discord.ext import commands
 class MiscMixin:
     @commands.command(aliases=["gw2wiki"])
     async def wiki(self, ctx, *, search):
-        """Search the Guild wars 2 wiki, append a language to search localized
+        """Search the Guild wars 2 wiki
         
-        Available languages: en, de, fr, es
-        No language defaults to en
+        Append a 2-character language tag to search in the localized wikis
+        Available languages:
+        en
+        de
+        fr
+        es
+        
+        Defaults to en
+
+        Examples:
+        Search for Lion's Arch:
+        $wiki Lion's Arch
+        Search it in the german wiki:
+        $wiki Löwenstein de
         """
         if len(search) > 300:
             await ctx.send("Search too long")

--- a/guildwars2/misc.py
+++ b/guildwars2/misc.py
@@ -11,14 +11,29 @@ from discord.ext import commands
 class MiscMixin:
     @commands.command(aliases=["gw2wiki"])
     async def wiki(self, ctx, *, search):
-        """Search the Guild wars 2 wiki"""
+        """Search the Guild wars 2 wiki, append a language to search localized
+        
+        Available languages: en, de, fr, es
+        No language defaults to en
+        """
         if len(search) > 300:
             await ctx.send("Search too long")
             return
-        wiki = "https://wiki.guildwars2.com"
+        wiki = {"en": "https://wiki.guildwars2.com",
+            "de": "https://wiki-de.guildwars2.com",
+            "fr": "https://wiki-fr.guildwars2.com",
+            "es": "https://wiki-es.guildwars2.com"}
+        searchurl = {"en": "{}/index.php?title=Special%3ASearch&search={}",
+               "de": "{}/index.php?search={}&title=Spezial%3ASuche&",
+               "fr": "{}/index.php?search={}&title=Spécial%3ARecherche",
+               "es": "{}/index.php?title=Especial%3ABuscar&search={}"}
+        lang = search.split(" ")[-1]
+        if lang in wiki:
+            search = search[:-3]
+        else:
+            lang = "en"
         search = search.replace(" ", "+")
-        url = ("{}/index.php?title=Special%3ASearch&"
-               "Search&search={}".format(wiki, search))
+        url = (searchurl[lang].format(wiki[lang], search))
         async with self.session.get(url) as r:
             if r.history:
                 embed = await self.search_results_embed(
@@ -37,109 +52,7 @@ class MiscMixin:
                     await ctx.send("No results")
                     return
         embed = await self.search_results_embed(
-            ctx, "Wiki", posts, base_url=wiki)
-        try:
-            await ctx.send(embed=embed)
-        except discord.Forbidden:
-            await ctx.send("Need permission to embed links")
-    
-    @commands.command(aliases=["gw2wikide"])
-    async def wikide(self, ctx, *, search):
-        """Durchsuche das deutsche Guild Wars 2 Wiki"""
-        if len(search) > 300:
-            await ctx.send("Search too long")
-            return
-        wiki = "https://wiki-de.guildwars2.com"
-        search = search.replace(" ", "+")
-        url = ("{}/index.php?search={}&title=Spezial%3ASuche&".format(
-            wiki, search))
-        async with self.session.get(url) as r:
-            if r.history:
-                embed = await self.search_results_embed(
-                    ctx, "Wiki-de", exact_match=r)
-                try:
-                    await ctx.send(embed=embed)
-                except discord.Forbidden:
-                    await ctx.send("Need permission to embed links")
-                return
-            else:
-                results = await r.text()
-                soup = BeautifulSoup(results, 'html.parser')
-                posts = soup.find_all(
-                    "div", {"class": "mw-search-result-heading"})[:5]
-                if not posts:
-                    await ctx.send("No results")
-                    return
-        embed = await self.search_results_embed(
-            ctx, "Wiki-de", posts, base_url=wiki)
-        try:
-            await ctx.send(embed=embed)
-        except discord.Forbidden:
-            await ctx.send("Need permission to embed links")
-    
-    @commands.command(aliases=["gw2wikifr"])
-    async def wikifr(self, ctx, *, search):
-        """Cherche le wiki francais de Guild Wars 2"""
-        if len(search) > 300:
-            await ctx.send("Search too long")
-            return
-        wiki = "https://wiki-fr.guildwars2.com"
-        search = search.replace(" ", "+")
-        url = ("{}/index.php?search={}&title=Spécial%3ARecherche".format(
-            wiki, search))
-        async with self.session.get(url) as r:
-            if r.history:
-                embed = await self.search_results_embed(
-                    ctx, "Wiki-fr", exact_match=r)
-                try:
-                    await ctx.send(embed=embed)
-                except discord.Forbidden:
-                    await ctx.send("Need permission to embed links")
-                return
-            else:
-                results = await r.text()
-                soup = BeautifulSoup(results, 'html.parser')
-                posts = soup.find_all(
-                    "div", {"class": "mw-search-result-heading"})[:5]
-                if not posts:
-                    await ctx.send("No results")
-                    return
-        embed = await self.search_results_embed(
-            ctx, "Wiki-fr", posts, base_url=wiki)
-        try:
-            await ctx.send(embed=embed)
-        except discord.Forbidden:
-            await ctx.send("Need permission to embed links")
-    
-    @commands.command(aliases=["gw2wikies"])
-    async def wikies(self, ctx, *, search):
-        """Search the spanish Guild wars 2 wiki"""
-        if len(search) > 300:
-            await ctx.send("Search too long")
-            return
-        wiki = "https://wiki-es.guildwars2.com"
-        search = search.replace(" ", "+")
-        url = ("{}/index.php?title=Especial%3ABuscar&search={}".format(
-            wiki, search))
-        async with self.session.get(url) as r:
-            if r.history:
-                embed = await self.search_results_embed(
-                    ctx, "Wiki-es", exact_match=r)
-                try:
-                    await ctx.send(embed=embed)
-                except discord.Forbidden:
-                    await ctx.send("Need permission to embed links")
-                return
-            else:
-                results = await r.text()
-                soup = BeautifulSoup(results, 'html.parser')
-                posts = soup.find_all(
-                    "div", {"class": "mw-search-result-heading"})[:5]
-                if not posts:
-                    await ctx.send("No results")
-                    return
-        embed = await self.search_results_embed(
-            ctx, "Wiki-es", posts, base_url=wiki)
+            ctx, "Wiki", posts, base_url=wiki[lang])
         try:
             await ctx.send(embed=embed)
         except discord.Forbidden:

--- a/guildwars2/misc.py
+++ b/guildwars2/misc.py
@@ -42,6 +42,108 @@ class MiscMixin:
             await ctx.send(embed=embed)
         except discord.Forbidden:
             await ctx.send("Need permission to embed links")
+    
+    @commands.command(aliases=["gw2wikide"])
+    async def wikide(self, ctx, *, search):
+        """Durchsuche das deutsche Guild Wars 2 Wiki"""
+        if len(search) > 300:
+            await ctx.send("Search too long")
+            return
+        wiki = "https://wiki-de.guildwars2.com"
+        search = search.replace(" ", "+")
+        url = ("{}/index.php?search={}&title=Spezial%3ASuche&".format(
+            wiki, search))
+        async with self.session.get(url) as r:
+            if r.history:
+                embed = await self.search_results_embed(
+                    ctx, "Wiki-de", exact_match=r)
+                try:
+                    await ctx.send(embed=embed)
+                except discord.Forbidden:
+                    await ctx.send("Need permission to embed links")
+                return
+            else:
+                results = await r.text()
+                soup = BeautifulSoup(results, 'html.parser')
+                posts = soup.find_all(
+                    "div", {"class": "mw-search-result-heading"})[:5]
+                if not posts:
+                    await ctx.send("No results")
+                    return
+        embed = await self.search_results_embed(
+            ctx, "Wiki-de", posts, base_url=wiki)
+        try:
+            await ctx.send(embed=embed)
+        except discord.Forbidden:
+            await ctx.send("Need permission to embed links")
+    
+    @commands.command(aliases=["gw2wikifr"])
+    async def wikifr(self, ctx, *, search):
+        """Cherche le wiki francais de Guild Wars 2"""
+        if len(search) > 300:
+            await ctx.send("Search too long")
+            return
+        wiki = "https://wiki-fr.guildwars2.com"
+        search = search.replace(" ", "+")
+        url = ("{}/index.php?search={}&title=Spécial%3ARecherche".format(
+            wiki, search))
+        async with self.session.get(url) as r:
+            if r.history:
+                embed = await self.search_results_embed(
+                    ctx, "Wiki-fr", exact_match=r)
+                try:
+                    await ctx.send(embed=embed)
+                except discord.Forbidden:
+                    await ctx.send("Need permission to embed links")
+                return
+            else:
+                results = await r.text()
+                soup = BeautifulSoup(results, 'html.parser')
+                posts = soup.find_all(
+                    "div", {"class": "mw-search-result-heading"})[:5]
+                if not posts:
+                    await ctx.send("No results")
+                    return
+        embed = await self.search_results_embed(
+            ctx, "Wiki-fr", posts, base_url=wiki)
+        try:
+            await ctx.send(embed=embed)
+        except discord.Forbidden:
+            await ctx.send("Need permission to embed links")
+    
+    @commands.command(aliases=["gw2wikies"])
+    async def wikies(self, ctx, *, search):
+        """Search the spanish Guild wars 2 wiki"""
+        if len(search) > 300:
+            await ctx.send("Search too long")
+            return
+        wiki = "https://wiki-es.guildwars2.com"
+        search = search.replace(" ", "+")
+        url = ("{}/index.php?title=Especial%3ABuscar&search={}".format(
+            wiki, search))
+        async with self.session.get(url) as r:
+            if r.history:
+                embed = await self.search_results_embed(
+                    ctx, "Wiki-es", exact_match=r)
+                try:
+                    await ctx.send(embed=embed)
+                except discord.Forbidden:
+                    await ctx.send("Need permission to embed links")
+                return
+            else:
+                results = await r.text()
+                soup = BeautifulSoup(results, 'html.parser')
+                posts = soup.find_all(
+                    "div", {"class": "mw-search-result-heading"})[:5]
+                if not posts:
+                    await ctx.send("No results")
+                    return
+        embed = await self.search_results_embed(
+            ctx, "Wiki-es", posts, base_url=wiki)
+        try:
+            await ctx.send(embed=embed)
+        except discord.Forbidden:
+            await ctx.send("Need permission to embed links")
 
     @commands.command(hidden=True)
     async def dulfy(self, ctx, *, search):

--- a/guildwars2/misc.py
+++ b/guildwars2/misc.py
@@ -35,17 +35,17 @@ class MiscMixin:
             "de": "https://wiki-de.guildwars2.com",
             "fr": "https://wiki-fr.guildwars2.com",
             "es": "https://wiki-es.guildwars2.com"}
-        searchurl = {"en": "{}/index.php?title=Special%3ASearch&search={}",
+        search_url = {"en": "{}/index.php?title=Special%3ASearch&search={}",
             "de": "{}/index.php?search={}&title=Spezial%3ASuche&",
             "fr": "{}/index.php?search={}&title=Spécial%3ARecherche",
             "es": "{}/index.php?title=Especial%3ABuscar&search={}"}
-        lang = search.split(" ")[-1]
+        lang = search.split(" ")[-1].lower()
         if lang in wiki:
             search = search[:-3]
         else:
             lang = "en"
         search = search.replace(" ", "+")
-        url = (searchurl[lang].format(wiki[lang], search))
+        url = (search_url[lang].format(wiki[lang], search))
         async with self.session.get(url) as r:
             if r.history:
                 embed = await self.search_results_embed(


### PR DESCRIPTION
Add the german, french and spanish wikis to the wiki command to allow players that don't know the english names to search in their language.

Languages are chosen by appending the language tag (en, de, fr, es) to the search command.
If no language is given it defaults to english so that the current usage stays unchanged.