### PR TITLE
Add Mythwright Gambit achievements to the killproof command

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -682,6 +682,40 @@
         ]
       },
       {
+        "name": "Mythwright Gambit",
+        "encounters": [{
+            "name": "Conjured Amalgamate",
+            "type": "single_achievement",
+            "id": 4423
+          },
+          {
+            "name": "Conjured Amalgamate CM",
+            "type": "single_achievement",
+            "id": 4416
+          },
+          {
+            "name": "Largos Twins",
+            "type": "single_achievement",
+            "id": 4364
+          },
+          {
+            "name": "Largos Twins CM",
+            "type": "single_achievement",
+            "id": 4429
+          },
+          {
+            "name": "Qadim",
+            "type": "single_achievement",
+            "id": 4396
+          },
+          {
+            "name": "Qadim CM",
+            "type": "single_achievement",
+            "id": 4355
+          }
+        ]
+      },
+      {
         "name": "Fractals",
         "encounters": [{
             "name": "Nightmare CM",


### PR DESCRIPTION
Names will have to be updated to be the same as in the API when the new raid is added to it. If that ever happens.

I didn't have a chance to test this locally as gw2bot doesn't want to run. I did double-check the ids.