### PR TITLE
Add Wing 7 achievements for the killproof command

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -718,6 +718,40 @@
         ]
       },
       {
+        "name": "The Key of Ahdashim",
+        "encounters": [{
+            "name": "Adina",
+            "type": "single_achievement",
+            "id": 4796
+          },
+          {
+            "name": "Adina CM",
+            "type": "single_achievement",
+            "id": 4803
+          },
+          {
+            "name": "Sabir",
+            "type": "single_achievement",
+            "id": 4801
+          },
+          {
+            "name": "Sabir CM",
+            "type": "single_achievement",
+            "id": 4779
+          },
+          {
+            "name": "Qadim the Peerless",
+            "type": "single_achievement",
+            "id": 4799
+          },
+          {
+            "name": "Qadim the Peerless CM",
+            "type": "single_achievement",
+            "id": 4800
+          }
+        ]
+      },
+      {
         "name": "Fractals",
         "encounters": [{
             "name": "Nightmare CM",


### PR DESCRIPTION
Adds The Key of Ahdashim raid to the killproof command. The new section includes
- Adina
- Adina CM
- Sabir
- Sabir CM
- Qadim the Peerless
- Qadim the Peerless CM

The order chosen (as the two first bosses can be done in any order) matches the order specified in the official API.