### PR TITLE
Suggested feature for tracking price of gold

### DIFF
--- a/guildwars2/__init__.py
+++ b/guildwars2/__init__.py
@@ -57,7 +57,7 @@ class GuildWars2(discord.ext.commands.Cog, AccountMixin, AchievementsMixin,
             self.font = ImageFont.load_default()
         self.tasks = [
             self.game_update_checker, self.daily_checker, self.news_checker,
-            self.gem_tracker, self.world_population_checker,
+            self.gem_tracker, self.coin_tracker, self.world_population_checker,
             self.guild_synchronizer, self.boss_notifier,
             self.forced_account_names, self.event_reminder_task,
             self.worldsync_task

--- a/guildwars2/commerce.py
+++ b/guildwars2/commerce.py
@@ -266,6 +266,11 @@ class CommerceMixin:
         results = await self.call_api(endpoint)
         return results["quantity"]
 
+    async def get_coins_per_gem(self, quantity=400):
+        endpoint = "commerce/exchange/gems?quantity={}".format(quantity)
+        results = await self.call_api(endpoint)
+        return results["coins_per_gem"]
+
     @gem.command(name="track", usage="<gold>")
     async def gem_track(self, ctx, gold: int = 0):
         """Receive a notification when cost of 400 gems drops below given cost
@@ -295,4 +300,34 @@ class CommerceMixin:
                                   "me blocked, or disabled DMs in this "
                                   "server. Aborting.")
         await self.bot.database.set(user, {"gemtrack": price}, self)
+        await ctx.send("Successfully set")
+
+    @gem.command(name="cointrack", usage="<gems>")
+    async def coin_track(self, ctx, gems: int = 0):
+        """Receive a notification when cost of 250 coins drops below given gem cost
+
+        For example, if you set cost to 900, you will get a notification when
+        price of 250 gold drops below 900 gems
+        """
+        user = ctx.author
+        if not gems:
+            doc = await self.bot.database.get(user, self)
+            current = doc.get("cointrack")
+            if current:
+                return await ctx.send(
+                    "You'll currently be notified if "
+                    "price of 250 gold drops below **{}** gems".format(
+                        current))
+            else:
+                return await ctx.send_help(ctx.command)
+        if not 500 <= gems <= 2000:
+            return await ctx.send("Invalid value")
+        try:
+            await user.send("You will be notified when price of 250 gold "
+                            "drops below {} gems".format(gems))
+        except:
+            return await ctx.send("Couldn't send a DM to you. Either you have "
+                                  "me blocked, or disabled DMs in this "
+                                  "server. Aborting.")
+        await self.bot.database.set(user, {"cointrack": gems}, self)
         await ctx.send("Successfully set")


### PR DESCRIPTION
Some of us like to buy gold occasionally, and it would be nice to be notified if that price gets to a certain threshold, too. Here's a suggestion for a new command: `gem.cointrack ###`.

I don't know how to set up a testing environment, so I can't tell if this works or not. I would welcome any documentation on how you'd like me to test it. Otherwise, let me know if any errors come up.

Thanks!