### PR TITLE
MIT -> GNU GPL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,21 @@
-MIT License
+GNU GENERAL PUBLIC LICENSE
 
-Copyright (c) 2017 Maselkov
+GW2Bot is a free and open-source interactive software tool (“bot”)
+created for use exclusively with the Discord application, and is
+designed to provide helpful and convenient features that compliment
+Guild Wars 2 (GW2) gameplay.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright (c) 2022 Maselkov
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Changed to [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.en.html) to reflect what is stated in the ToS & Privacy Policy on the website.

Btw it seems like you must remove the existing `LICENSE` file first and then add this one. See [here](https://github.com/orgs/community/discussions/23555). Note this change in license does not effect previous versions or forks of GW2Bot; only new changes added hereafter.