### PR TITLE
Added missing bosses to gamedata.json

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1960,6 +1960,10 @@
       "icon": "https://wiki.guildwars2.com/images/c/c0/Mini_Whisper_of_Jormag.png",
       "name": "Whisper of Jormag"
     },
+    "22836": {
+      "icon": "https://wiki.guildwars2.com/images/1/16/Mini_Varinia_Stormsounder.png",
+      "name": "Varinia Stormsounder"
+    },
     "24033": {
       "icon": "https://wiki.guildwars2.com/images/9/98/Mini_Mai_Trin.png",
       "name": "Captain Mai Trin & Echo Of Scarlet Briar"

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1924,6 +1924,90 @@
       "icon": "https://i.imgur.com/xw2e83k.png",
       "name": "Arkk"
     },
+    "23254": {
+      "icon": "https://i.imgur.com/R5w3sXS.png",
+      "name": "Ai, Keeper of the Peak"
+    },
+    "22154": {
+      "icon": "https://wiki.guildwars2.com/images/f/f4/Mini_Icebrood_Construct.png",
+      "name": "Legendary Icebrood Construct"
+    },
+    "22343": {
+      "icon": "https://i.imgur.com/4wR8S7r.png",
+      "name": "Voice of the Fallen and Claw of the Fallen"
+    },
+    "22481": {
+      "icon": "https://i.imgur.com/4wR8S7r.png",
+      "name": "Voice of the Fallen and Claw of the Fallen"
+    },
+    "22315": {
+      "icon": "https://i.imgur.com/4wR8S7r.png",
+      "name": "Voice of the Fallen and Claw of the Fallen"
+    },
+    "22492": {
+      "icon": "https://i.imgur.com/v81xayj.png",
+      "name": "Fraenir of Jormag"
+    },
+    "22436": {
+      "icon": "https://i.imgur.com/v81xayj.png",
+      "name": "Fraenir of Jormag"
+    },
+    "22521": {
+      "icon": "https://wiki.guildwars2.com/images/8/8e/Mini_Boneskinner.png",
+      "name": "Boneskinner"
+    },
+    "22711": {
+      "icon": "https://wiki.guildwars2.com/images/c/c0/Mini_Whisper_of_Jormag.png",
+      "name": "Whisper of Jormag"
+    },
+    "24033": {
+      "icon": "https://wiki.guildwars2.com/images/9/98/Mini_Mai_Trin.png",
+      "name": "Captain Mai Trin & Echo Of Scarlet Briar"
+    },
+    "24768": {
+      "icon": "https://wiki.guildwars2.com/images/c/cd/Mini_Holographic_Scarlet.png",
+      "name": "Captain Mai Trin & Echo Of Scarlet Briar"
+    },
+    "23957": {
+      "icon": "https://i.imgur.com/PhChXQ4.png",
+      "name": "Ankka"
+    },
+    "24485": {
+      "icon": "https://i.imgur.com/9qzjr9H.png",
+      "name": "Minister Li"
+    },
+    "24266": {
+      "icon": "https://i.imgur.com/9qzjr9H.png",
+      "name": "Minister Li"
+    },
+    "1378": {
+      "icon": "https://i.imgur.com/wwJk2AG.png",
+      "name": "The Dragonvoid"
+    },
+    "24375": {
+      "icon": "https://i.imgur.com/wwJk2AG.png",
+      "name": "The Dragonvoid"
+    },
+    "43488": {
+      "icon": "https://i.imgur.com/wwJk2AG.png",
+      "name": "The Dragonvoid"
+    },
+    "25413": {
+      "icon": "https://i.imgur.com/4PWffRa.png",
+      "name": "Watchknight Triumvirate"
+    },
+    "25415": {
+      "icon": "https://i.imgur.com/4PWffRa.png",
+      "name": "Watchknight Triumvirate"
+    },
+    "25419": {
+      "icon": "https://i.imgur.com/4PWffRa.png",
+      "name": "Watchknight Triumvirate"
+    },
+    "21333": {
+      "icon": "https://wiki.guildwars2.com/images/d/d9/Mini_Freezie.png",
+      "name": "Freezie"
+    },
     "16199": {
       "icon": "https://wiki.guildwars2.com/images/8/8f/Mini_Professor_Mew.png",
       "name": "Standard Kitty Golem"

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1933,15 +1933,15 @@
       "name": "Legendary Icebrood Construct"
     },
     "22343": {
-      "icon": "https://i.imgur.com/4wR8S7r.png",
+      "icon": "https://i.imgur.com/ENCeHIg.png",
       "name": "Voice of the Fallen and Claw of the Fallen"
     },
     "22481": {
-      "icon": "https://i.imgur.com/4wR8S7r.png",
+      "icon": "https://i.imgur.com/ENCeHIg.png",
       "name": "Voice of the Fallen and Claw of the Fallen"
     },
     "22315": {
-      "icon": "https://i.imgur.com/4wR8S7r.png",
+      "icon": "https://i.imgur.com/ENCeHIg.png",
       "name": "Voice of the Fallen and Claw of the Fallen"
     },
     "22492": {

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1775,10 +1775,30 @@
       "name": "Slothasor",
       "api_name": "slothasor"
     },
+    "16088": {
+      "icon": "https://i.imgur.com/oeDU3JB.png",
+      "name": "Bandit Trio",
+      "api_name": "bandit_trio"
+    },
+    "16137": {
+      "icon": "https://i.imgur.com/oeDU3JB.png",
+      "name": "Bandit Trio",
+      "api_name": "bandit_trio"
+    },
+    "16125": {
+      "icon": "https://i.imgur.com/oeDU3JB.png",
+      "name": "Bandit Trio",
+      "api_name": "bandit_trio"
+    },
     "16115": {
       "icon": "https://wiki.guildwars2.com/images/5/5d/Mini_Matthias_Abomination.png",
       "name": "Matthias Gabrel",
       "api_name": "matthias"
+    },
+    "16253": {
+      "icon": "https://wiki.guildwars2.com/images/b/b5/Mini_McLeod_the_Silent.png",
+      "name": "Escort",
+      "api_name": "escort"
     },
     "16235": {
       "icon": "https://wiki.guildwars2.com/images/e/ea/Mini_Keep_Construct.png",
@@ -1814,6 +1834,31 @@
       "icon": "https://wiki.guildwars2.com/images/d/d4/Mini_Desmina.png",
       "name": "Soulless Horror",
       "api_name": "soulless_horror"
+    },
+    "19828": {
+      "icon": "https://wiki.guildwars2.com/images/c/c4/Silver_River_of_Souls_Trophy.png",
+      "name": "River of Souls",
+      "api_name": "river_of_souls"
+    },
+    "19691": {
+      "icon": "https://wiki.guildwars2.com/images/3/37/Mini_Broken_King.png",
+      "name": "Broken King",
+      "api_name": "statues_of_grenth"
+    },
+    "19536": {
+      "icon": "https://i.imgur.com/bb7VOtW.png",
+      "name": "Eater of Souls",
+      "api_name": "statues_of_grenth"
+    },
+    "19651": {
+      "icon": "https://i.imgur.com/Rr8ToDY.png",
+      "name": "Eyes 👀",
+      "api_name": "statues_of_grenth"
+    },
+    "19844": {
+      "icon": "https://i.imgur.com/Rr8ToDY.png",
+      "name": "Eyes 👀",
+      "api_name": "statues_of_grenth"
     },
     "19450": {
       "icon": "https://wiki.guildwars2.com/images/e/e4/Mini_Dhuum.png",
@@ -1854,51 +1899,6 @@
       "icon": "https://wiki.guildwars2.com/images/8/8b/Mini_Qadim_the_Peerless.png",
       "name": "Qadim the Peerless",
       "api_name": "qadim_the_peerless"
-    },
-    "16088": {
-      "icon": "https://i.imgur.com/oeDU3JB.png",
-      "name": "Bandit Trio",
-      "api_name": "bandit_trio"
-    },
-    "16137": {
-      "icon": "https://i.imgur.com/oeDU3JB.png",
-      "name": "Bandit Trio",
-      "api_name": "bandit_trio"
-    },
-    "16125": {
-      "icon": "https://i.imgur.com/oeDU3JB.png",
-      "name": "Bandit Trio",
-      "api_name": "bandit_trio"
-    },
-    "16253": {
-      "icon": "https://wiki.guildwars2.com/images/b/b5/Mini_McLeod_the_Silent.png",
-      "name": "Escort",
-      "api_name": "escort"
-    },
-    "19828": {
-      "icon": "https://wiki.guildwars2.com/images/c/c4/Silver_River_of_Souls_Trophy.png",
-      "name": "River of Souls",
-      "api_name": "river_of_souls"
-    },
-    "19691": {
-      "icon": "https://wiki.guildwars2.com/images/3/37/Mini_Broken_King.png",
-      "name": "Broken King",
-      "api_name": "statues_of_grenth"
-    },
-    "19536": {
-      "icon": "https://i.imgur.com/bb7VOtW.png",
-      "name": "Eater of Souls",
-      "api_name": "statues_of_grenth"
-    },
-    "19651": {
-      "icon": "https://i.imgur.com/Rr8ToDY.png",
-      "name": "Eyes 👀",
-      "api_name": "statues_of_grenth"
-    },
-    "19844": {
-      "icon": "https://i.imgur.com/Rr8ToDY.png",
-      "name": "Eyes 👀",
-      "api_name": "statues_of_grenth"
     },
     "17021": {
       "icon": "https://i.imgur.com/szBjyva.png",

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1905,7 +1905,7 @@
       "name": "MAMA"
     },
     "17028": {
-      "icon": "https://wiki.guildwars2.com/images/d/dc/Siax_the_Corrupted.jpg",
+      "icon": "https://wiki.guildwars2.com/images/d/d0/Mini_Toxic_Warlock.png",
       "name": "Siax the Corrupted"
     },
     "16948": {

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1771,7 +1771,7 @@
       "api_name": "sabetha"
     },
     "16123": {
-      "icon": "https://wiki.guildwars2.com/images/e/ed/Mini_Slubling.png",
+      "icon": "https://wiki.guildwars2.com/images/1/12/Mini_Slothasor.png",
       "name": "Slothasor",
       "api_name": "slothasor"
     },
@@ -1826,12 +1826,12 @@
       "api_name": "conjured_amalgamate"
     },
     "21105": {
-      "icon": "https://i.imgur.com/6O5MT7v.png",
+      "icon": "https://i.imgur.com/NdpoMGs.png",
       "name": "Twin Largos",
       "api_name": "twin_largos"
     },
     "21089": {
-      "icon": "https://i.imgur.com/6O5MT7v.png",
+      "icon": "https://i.imgur.com/NdpoMGs.png",
       "name": "Twin Largos",
       "api_name": "twin_largos"
     },
@@ -1856,17 +1856,17 @@
       "api_name": "qadim_the_peerless"
     },
     "16088": {
-      "icon": "https://i.imgur.com/UZZQUdf.png",
+      "icon": "https://i.imgur.com/oeDU3JB.png",
       "name": "Bandit Trio",
       "api_name": "bandit_trio"
     },
     "16137": {
-      "icon": "https://i.imgur.com/UZZQUdf.png",
+      "icon": "https://i.imgur.com/oeDU3JB.png",
       "name": "Bandit Trio",
       "api_name": "bandit_trio"
     },
     "16125": {
-      "icon": "https://i.imgur.com/UZZQUdf.png",
+      "icon": "https://i.imgur.com/oeDU3JB.png",
       "name": "Bandit Trio",
       "api_name": "bandit_trio"
     },
@@ -1876,7 +1876,7 @@
       "api_name": "escort"
     },
     "19828": {
-      "icon": "https://wiki.guildwars2.com/images/thumb/7/7b/Gold_River_of_Souls_Trophy.jpg/220px-Gold_River_of_Souls_Trophy.jpg",
+      "icon": "https://wiki.guildwars2.com/images/c/c4/Silver_River_of_Souls_Trophy.png",
       "name": "River of Souls",
       "api_name": "river_of_souls"
     },
@@ -1886,22 +1886,22 @@
       "api_name": "statues_of_grenth"
     },
     "19536": {
-      "icon": "https://wiki.guildwars2.com/images/thumb/2/24/Eater_of_Souls_%28Hall_of_Chains%29.jpg/194px-Eater_of_Souls_%28Hall_of_Chains%29.jpg",
+      "icon": "https://i.imgur.com/bb7VOtW.png",
       "name": "Eater of Souls",
       "api_name": "statues_of_grenth"
     },
     "19651": {
-      "icon": "https://wiki.guildwars2.com/images/thumb/a/a7/Eye_of_Fate.jpg/188px-Eye_of_Fate.jpg",
+      "icon": "https://i.imgur.com/Rr8ToDY.png",
       "name": "Eyes 👀",
       "api_name": "statues_of_grenth"
     },
     "19844": {
-      "icon": "https://wiki.guildwars2.com/images/thumb/a/a7/Eye_of_Fate.jpg/188px-Eye_of_Fate.jpg",
+      "icon": "https://i.imgur.com/Rr8ToDY.png",
       "name": "Eyes 👀",
       "api_name": "statues_of_grenth"
     },
     "17021": {
-      "icon": "http://dulfy.net/wp-content/uploads/2016/11/gw2-nightmare-fractal-teaser.jpg",
+      "icon": "https://i.imgur.com/szBjyva.png",
       "name": "MAMA"
     },
     "17028": {
@@ -1909,19 +1909,19 @@
       "name": "Siax the Corrupted"
     },
     "16948": {
-      "icon": "https://wiki.guildwars2.com/images/5/57/Champion_Toxic_Hybrid.jpg",
+      "icon": "https://wiki.guildwars2.com/images/5/5e/Mini_Toxic_Hybrid.png",
       "name": "Ensolyss"
     },
     "17632": {
-      "icon": "https://wiki.guildwars2.com/images/c/c1/Skorvald_the_Shattered.jpg",
+      "icon": "https://i.imgur.com/N202B0m.png",
       "name": "Skorvald"
     },
     "17949": {
-      "icon": "https://wiki.guildwars2.com/images/b/b4/Artsariiv.jpg",
+      "icon": "https://i.imgur.com/sCQxF5g.png",
       "name": "Artsariiv"
     },
     "17759": {
-      "icon": "https://wiki.guildwars2.com/images/5/5f/Arkk.jpg",
+      "icon": "https://i.imgur.com/xw2e83k.png",
       "name": "Arkk"
     },
     "16199": {


### PR DESCRIPTION
Added icons and data for missing boss encounters:

- Ai, Keeper of the Peak (Sunqua Peak),
- Legendary Icebrood Construct (Shiverpeaks Pass),
- Voice of the Fallen and Claw of the Fallen,
- Fraenir of Jormag,
- Boneskinner,
- Whisper of Jormag,
- Captain Mai Trin & Echo Of Scarlet Briar (Aetherblade Hideout),
- Ankka (Xunlai Jade Junkyard),
- Minister Li (Kaineng Overlook),
- The Dragonvoid (Harvest Temple),
- Watchknight Triumvirate (Old Lion's Court),
- Freezie (Secret Lair of the Snowmen)