### PR TITLE
Add OLC Strikes to KP command

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1378,6 +1378,21 @@
             "name": "Harvest Temple CM",
             "type": "single_achievement",
             "id": 6532
+          },
+          {
+            "name": "Old Lion's Court",
+            "type": "single_achievement",
+            "id": 6797
+          },
+          {
+            "name": "Old Lion's Court CM",
+            "type": "single_achievement",
+            "id": 6804
+          },
+          {
+            "name": "Old Lion's Court: Fear Not This Knight",
+            "type": "single_achievement",
+            "id": 6778
           }
         ]
       }


### PR DESCRIPTION
This adds the OLC strikes to the /kp command by updating the gamedata.json file.

The three achievements for OLC included are:

* Old Lion's Court, Achievement ID: 6797
* Old Lion's Court CM, Achievement ID: 6804
* Old Lion's Court: Fear Not This Knight, Achievement ID: 6778


Link to the GW2 API with the achievement IDs: https://api.guildwars2.com/v2/achievements?ids=6797,6804,6778