### PR TITLE
Adds EoD Priority Strike to the /daily command

### DIFF
--- a/guildwars2/daily.py
+++ b/guildwars2/daily.py
@@ -117,7 +117,7 @@ class DailyMixin:
                                              tomorrow=tomorrow)
                 value = "\n".join(fractals[0])
             elif category == "strikes":
-                category = "Priority Strike"
+                category = "Priority Strikes"
                 strikes = self.get_strike(interaction, tomorrow=tomorrow)
                 value = strikes
             else:
@@ -235,9 +235,14 @@ class DailyMixin:
 
     def get_strike(self, ctx, tomorrow=False):
         day = self.get_year_day(tomorrow=tomorrow)
-        index = day % len(self.gamedata["strike_missions"])
-        return (self.get_emoji(ctx, "daily strike") +
-                self.gamedata["strike_missions"][index])
+        ibs_strikes = self.gamedata["strike_missions"]
+        eod_strikes = self.gamedata["eod_strike_missions"]
+        ibs_index = day % len(ibs_strikes)
+        eod_index = day % len(eod_strikes)
+        strike_emoji = self.get_emoji(ctx, "daily strike")
+        ibs_daily = strike_emoji + ibs_strikes[ibs_index]
+        eod_daily = strike_emoji + eod_strikes[eod_index]
+        return "\n".join([ibs_daily, eod_daily])
 
     def get_instabilities(self, fractal_level, *, tomorrow=False, ctx=None):
         fractal_level = str(fractal_level)

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -92,6 +92,13 @@
     "Whisper of Jormag",
     "Boneskinner"
   ],
+  "eod_strike_missions": [
+    "Aetherblade Hideout",
+    "Xunlai Jade Junkyard",
+    "Kaening Overlook",
+    "Harvest Temple",
+    "Old Lion's Court"
+  ],
   "fractals": {
     "Aetherblade": [
       14,


### PR DESCRIPTION
This adds the EoD Priority Strike to the `/daily` command. It follows the same pattern as IBS daily strikes, and adds the list of strikes to the JSON data and then uses an index based on today's date.

We could probably update this to use the GW2 API, as there is now an achievement category endpoint that [returns the IDs of the current strikes](https://api.guildwars2.com/v2/achievements/categories/250). Doing so would be future-proof to other strike additions. I didn't have the time at the moment, but I may do another PR in the future to make that update 😄 
