### PR TITLE
New GW2 updater handling

### DIFF
--- a/guildwars2/notifiers.py
+++ b/guildwars2/notifiers.py
@@ -903,7 +903,7 @@ class NotiifiersMixin:
     async def before_news_checker(self):
         await self.bot.wait_until_ready()
 
-    @tasks.loop(seconds=10)
+    @tasks.loop(minutes=1)
     async def game_update_checker(self):
         if await self.game_build_changed():
             await self.rebuild_database()

--- a/guildwars2/notifiers.py
+++ b/guildwars2/notifiers.py
@@ -588,7 +588,7 @@ class NotiifiersMixin:
 
                     # Sanitize HTML output
                     # Remove tag parameters
-                    patch_notes = re.sub(r"<([a-z]{,5}) .*>", r"<\1>", patch_notes)
+                    patch_notes = re.sub(r"<([a-z]{,5}) .*?>", r"<\1>", patch_notes)
                     # Remove closing tags
                     patch_notes = patch_notes.replace("</span>", "")
                     patch_notes = patch_notes.replace("</div>", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ tenacity
 matplotlib
 discord-py-interactions
 httpx
+feedparser
+html2markdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ tenacity
 matplotlib
 discord-py-interactions
 httpx
-feedparser
 html2markdown


### PR DESCRIPTION
The basic idea is as follows: 
1. Check the RSS feed for the latest post
2. Retrieve HTML source for that post from forum
3. Do some regex and markdown parsing magic to get the patch notes out of that.
4. Keep track in the database of number of already sent out messages per forum post.
5. If amount of comments in the latest post exceeds the amount stored in the database, send out the new ones.

Worked in my test instance, but better test it by yourself first. The 4 latest patch notes might be pushed out on startup since the database is not populated.

Use for example the following mongosh line to test the behaviour. Alter the count value to emulate the behavior of new posts.
`db.gw2.updates.updateOne({"title": 'Game Update Notes: July 18, 2023'}, { "$set": {"title": 'Game Update Notes: July 18, 2023', "count": 2}})` will send out the last 2 update notes.
