### PR TITLE
Add Silent Surf CM achievements to KP

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1296,6 +1296,16 @@
             "name": "Sunqua Peak: Dancing with Demons",
             "type": "single_achievement",
             "id": 5439
+          },
+          {
+            "name": "Silent Surf CM",
+            "type": "single_achievement",
+            "id": 6938
+          },
+          {
+            "name": "Silent Surf: Stalwart Serpents",
+            "type": "single_achievement",
+            "id": 6950
           }
         ]
       },


### PR DESCRIPTION
This adds the Silent Surf CM and CM title to the `/kp` command.

Achievement IDs can be seen here: https://api.guildwars2.com/v2/achievements?ids=6938,6950