### PR TITLE
Updated gamedata.json

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -2065,7 +2065,7 @@
       "name": "Dagda"
     },
     "25989": {
-      "icon": "https://wiki.guildwars2.com/wiki/File:Mini_Cerus.png",
+      "icon": "https://wiki.guildwars2.com/images/e/e0/Mini_Cerus.png",
       "name": "Cerus"
     },
     "21333": {

--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1950,7 +1950,7 @@
     },
     "17028": {
       "icon": "https://wiki.guildwars2.com/images/d/d0/Mini_Toxic_Warlock.png",
-      "name": "Siax the Corrupted"
+      "name": "Siax"
     },
     "16948": {
       "icon": "https://wiki.guildwars2.com/images/5/5e/Mini_Toxic_Hybrid.png",
@@ -1971,6 +1971,14 @@
     "23254": {
       "icon": "https://i.imgur.com/R5w3sXS.png",
       "name": "Ai, Keeper of the Peak"
+    },
+    "25572": {
+      "icon": "https://wiki.guildwars2.com/images/3/31/Mini_Kanaxai.png",
+      "name": "Kanaxai, Scythe of House Aurkus"
+    },
+    "25577": {
+      "icon": "https://wiki.guildwars2.com/images/3/31/Mini_Kanaxai.png",
+      "name": "Kanaxai, Scythe of House Aurkus"
     },
     "22154": {
       "icon": "https://wiki.guildwars2.com/images/f/f4/Mini_Icebrood_Construct.png",
@@ -2052,6 +2060,14 @@
       "icon": "https://i.imgur.com/4PWffRa.png",
       "name": "Watchknight Triumvirate"
     },
+    "25705": {
+      "icon": "https://wiki.guildwars2.com/images/5/52/Mini_Dagda.png",
+      "name": "Dagda"
+    },
+    "25989": {
+      "icon": "https://wiki.guildwars2.com/wiki/File:Mini_Cerus.png",
+      "name": "Cerus"
+    },
     "21333": {
       "icon": "https://wiki.guildwars2.com/images/d/d9/Mini_Freezie.png",
       "name": "Freezie"
@@ -2081,7 +2097,7 @@
       "name": "Vital Kitty Golem"
     },
     "1": {
-      "icon": "https://wiki.guildwars2.com/images/3/35/WvW_Rank_up.png",
+      "icon": "https://wiki.guildwars2.com/images/4/40/Mini_Chest_of_the_Mists.png",
       "name": "WvW"
     }
   }


### PR DESCRIPTION
Added boss IDs and icons to gamedata.json:

Kanaxai, Scythe of House Aurkus (Silent Surf Fractal): 25572 normal mode
25577 challenge mode

Dagda (Cosmic Observatory Strike Mission):
25705

Cerus (Temple of Febe Strike Mission):
25989

Also changed "Siax the Corrupted" to just "Siax" to be less specific, because the normal mode and challenge mode bosses share the same ID but have different suffixes.

Also changed the icon for WvW encounters to Chest of the Mists icon for better visibility at small size.