### PR TITLE
Add Soto Strikes to kp command

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -1424,6 +1424,26 @@
             "id": 6778
           }
         ]
+      },
+      {
+        "name": "Secrets of the Obscure Strike Missions",
+        "encounters": [
+          {
+            "name": "Cosmic Observatory",
+            "type": "single_achievement",
+            "id": 7163
+          },
+          {
+            "name": "Cosmic Observatory CM",
+            "type": "single_achievement",
+            "id": 7678
+          },
+          {
+            "name": "Temple of Febe",
+            "type": "single_achievement",
+            "id": 7116
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
This adds the SoTo strikes (including new CO CM) to the `/kp` command.

Achievement IDs were verified on the GW2 API and command was run locally. Please see this link for the IDs: https://api.guildwars2.com/v2/achievements?ids=7163,7678,7116

* Cosmic Observatory: 7163
* Cosmic Observatory CM: 7678
* Temple of Febe: 7116