### PR TITLE
Added SoTO event timers to gamedata.json

### DIFF
--- a/guildwars2/gamedata.json
+++ b/guildwars2/gamedata.json
@@ -889,6 +889,72 @@
         ]
       }
     ],
+    "soto": [
+      {
+        "name": "Skywatch Archipelago",
+        "phases": [
+          {
+            "name": null,
+            "duration": 60
+          },
+          {
+            "name": "Unlocking the Wizard's Tower",
+            "duration": 25
+          },
+          {
+            "name": null,
+            "duration": 35
+          }
+        ]
+      },
+      {
+        "name": "Wizard's Tower",
+        "phases": [
+          {
+            "name": null,
+            "duration": 60
+          },
+          {
+            "name": "Skyscale Target Practice",
+            "duration": 40
+          },
+          {
+            "name": "Fly by Night",
+            "duration": 20
+          }
+        ]
+      },
+      {
+        "name": "Amnytas",
+        "phases": [
+          {
+            "name": "Defense of Amnytas",
+            "duration": 25
+          },
+          {
+            "name": null,
+            "duration": 95
+          }
+        ]
+      },
+      {
+        "name": "Convergences",
+        "phases": [
+          {
+            "name": null,
+            "duration": 90
+          },
+          {
+            "name": "Convergences (Public)",
+            "duration": 10
+          },
+          {
+            "name": null,
+            "duration": 80
+          }
+        ]
+      }
+    ],
     "day": [
       {
         "name": "Tyrian cycle",


### PR DESCRIPTION
Public convergences seem to be the only event on a 3-hour cycle.
I'm not sure if the first event occurs at 00:30 or 01:30 bot time.
Also I don't know if the 3-hour event cycle might break the bot somehow.
[Convergences in gamedata.json](https://github.com/Maselkov/GW2Bot/pull/151/files#diff-f96035da98fe067745b2ca27cedf28692180996fff0ea8927c8710a46528a538R940-R956)