### PR TITLE
fix: PathOfFire implies HeartOfThorns access

### DIFF
--- a/guildwars2/account.py
+++ b/guildwars2/account.py
@@ -73,6 +73,10 @@ class AccountMixin:
                     if d in access:
                         access.remove(d)
 
+                # Having PathOfFire access implies HeartOfThorns access.
+                if "PathOfFire" in access and "HeartOfThorns" not in access:
+                    access += "HeartOfThorns"
+
             def format_name(name):
                 return " ".join(re.findall(r'[A-Z\d][^A-Z\d]*', name))
 


### PR DESCRIPTION
Fixes #158

I tried to test this on my personal server but I couldn't get the bot to respond to my DM's to load the GW2Bot cog.